### PR TITLE
system-tests: Enable parallel network test execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,4 +134,4 @@ See `doc/ai/OVERVIEW.md` for comprehensive subsystem documentation including:
 
 **Keep docs in sync.** Update `CLAUDE.md` and `doc/ai/*` when discovering inconsistencies or implementing new features.
 
-**Network port conflict.** Only one QEMU instance with `--net` can run at a time (port 1234). See `doc/ai/DEBUGGING.md` for all QEMU wrapper options.
+**Network port.** System tests use dynamic port allocation for networking. When running QEMU manually with `--net`, it defaults to port 1234. Use `--net PORT` to specify a different port. See `doc/ai/DEBUGGING.md` for all QEMU wrapper options.

--- a/doc/ai/DEBUGGING.md
+++ b/doc/ai/DEBUGGING.md
@@ -167,13 +167,13 @@ The `./qemu_wrapper.sh` script provides flags for debugging:
 | `--gdb` | Enable GDB server on port 1234 |
 | `--wait` | Pause CPU until GDB attaches |
 | `--log` | Log QEMU events to `/tmp/sentientos.log` |
-| `--net` | Enable VirtIO network (port 1234) |
+| `--net [PORT]` | Enable VirtIO network (default port 1234) |
 | `--smp` | Enable all CPU cores |
 | `--capture` | Capture network traffic to `network.pcap` |
 
 Flags are set in `.cargo/config.toml` for `just run`.
 
-**Note:** Only one QEMU instance with `--net` can run at a time due to port 1234 conflict.
+**Note:** When running manually with `--net` without a port argument, only one QEMU instance can run at a time due to port 1234 conflict. System tests use dynamic port allocation to avoid this.
 
 ### Manual GDB
 

--- a/qemu_wrapper.sh
+++ b/qemu_wrapper.sh
@@ -29,7 +29,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --gdb          Let qemu listen on :1234 for gdb connections"
             echo "  --log          Log qemu events to /tmp/sentientos.log"
             echo "  --capture      Capture network traffic into network.pcap"
-            echo "  --net          Enable network card"
+            echo "  --net PORT     Enable network card with host port PORT (default: 1234)"
             echo "  -h, --help     Show this help message"
             echo "  --wait         Wait cpu until gdb is attached"
             exit 0
@@ -39,8 +39,14 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --net)
-            QEMU_CMD+=" -netdev user,id=netdev1,hostfwd=udp::1234-:1234 -device virtio-net-pci,netdev=netdev1"
             shift
+            if [[ "$1" =~ ^[0-9]+$ ]]; then
+                NET_PORT="$1"
+                shift
+            else
+                NET_PORT="1234"
+            fi
+            QEMU_CMD+=" -netdev user,id=netdev1,hostfwd=udp::${NET_PORT}-:1234 -device virtio-net-pci,netdev=netdev1"
             ;;
         --smp)
             QEMU_CMD+=" -smp $(nproc)"

--- a/system-tests/Cargo.lock
+++ b/system-tests/Cargo.lock
@@ -66,93 +66,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "fslock"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
-
-[[package]]
-name = "futures-task"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
-
-[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,12 +86,6 @@ dependencies = [
  "autocfg",
  "scopeguard",
 ]
-
-[[package]]
-name = "log"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
@@ -216,12 +123,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,12 +150,6 @@ name = "pin-project-lite"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
@@ -290,51 +185,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
-name = "scc"
-version = "2.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b202022bb57c049555430e11fc22fea12909276a80a4c3d368da36ac1d88ed"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c1eeaf4b6a87c7479688c6d52b9f1153cedd3c489300564f932b065c6eab95"
-
-[[package]]
-name = "serial_test"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
-dependencies = [
- "fslock",
- "futures",
- "log",
- "once_cell",
- "parking_lot",
- "scc",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "signal-hook-registry"
@@ -343,15 +197,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "slab"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -386,7 +231,6 @@ name = "system-tests"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "serial_test",
  "tokio",
 ]
 
@@ -430,28 +274,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/system-tests/Cargo.toml
+++ b/system-tests/Cargo.toml
@@ -6,5 +6,4 @@ edition = "2024"
 
 [dependencies]
 anyhow = { version = "1.0.94", features = ["backtrace"] }
-serial_test = { version = "3.2.0", features = ["file_locks"] }
 tokio = { version = "1.43.1", features = ["full"] }

--- a/system-tests/src/tests/basics.rs
+++ b/system-tests/src/tests/basics.rs
@@ -1,5 +1,3 @@
-use serial_test::file_serial;
-
 use crate::infra::qemu::{QemuInstance, QemuOptions};
 
 #[tokio::test]
@@ -14,7 +12,6 @@ async fn boot_single_core() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[file_serial]
 #[tokio::test]
 async fn boot_with_network() -> anyhow::Result<()> {
     QemuInstance::start_with(QemuOptions::default().add_network_card(true)).await?;

--- a/system-tests/src/tests/net.rs
+++ b/system-tests/src/tests/net.rs
@@ -1,9 +1,7 @@
-use serial_test::file_serial;
 use tokio::io::AsyncWriteExt;
 
 use crate::infra::qemu::{QemuInstance, QemuOptions};
 
-#[file_serial]
 #[tokio::test]
 async fn udp() -> anyhow::Result<()> {
     let mut sentientos =
@@ -14,8 +12,9 @@ async fn udp() -> anyhow::Result<()> {
         .await
         .expect("udp program must succeed to start");
 
+    let port = sentientos.network_port().expect("Network must be enabled");
     let socket = tokio::net::UdpSocket::bind("127.0.0.1:0").await?;
-    socket.connect("127.0.0.1:1234").await?;
+    socket.connect(format!("127.0.0.1:{}", port)).await?;
 
     socket.send("42\n".as_bytes()).await?;
     sentientos.stdout().assert_read_until("42\n").await;

--- a/system-tests/src/tests/signals.rs
+++ b/system-tests/src/tests/signals.rs
@@ -1,9 +1,7 @@
-use serial_test::file_serial;
 use tokio::io::AsyncWriteExt;
 
 use crate::infra::qemu::{QemuInstance, QemuOptions};
 
-#[file_serial]
 #[tokio::test]
 async fn should_exit_program() -> anyhow::Result<()> {
     let mut sentientos =

--- a/system-tests/src/tests/stress.rs
+++ b/system-tests/src/tests/stress.rs
@@ -1,10 +1,7 @@
 use std::time::{Duration, Instant};
 
-use serial_test::file_serial;
-
 use crate::infra::qemu::QemuInstance;
 
-#[file_serial]
 #[tokio::test]
 async fn stress() -> anyhow::Result<()> {
     let mut sentientos = QemuInstance::start().await?;


### PR DESCRIPTION
Add dynamic port allocation for QEMU networking to allow multiple tests with networking to run in parallel without port conflicts.

Changes:
- qemu_wrapper.sh: Accept optional PORT argument for --net flag
- QemuInstance: Find available port and expose via network_port()
- Remove #[file_serial] from all tests (no longer needed)
- Remove serial_test dependency from Cargo.toml
- Update docs to reflect new behavior

Previously only one QEMU instance could run with networking enabled due to the hardcoded port 1234 binding. Now each test instance allocates a unique host port that maps to the guest's port 1234.