### PR TITLE
ci: Run GitHub Actions on every push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: ci
 
 on:
   push:
-    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
Run CI on every push to any branch, not just main. Since we have our own runner, this is cheap and gives faster feedback.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>