### PR TITLE
feat: Dynamic port allocation for parallel QEMU instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /network.pcap
 /src/kernel/network.pcap
 /.gdb_history
+/.gdb-port
 /symbols
 /.direnv
 /.gdb_sources

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,4 +134,4 @@ See `doc/ai/OVERVIEW.md` for comprehensive subsystem documentation including:
 
 **Keep docs in sync.** Update `CLAUDE.md` and `doc/ai/*` when discovering inconsistencies or implementing new features.
 
-**Network port.** System tests use dynamic port allocation for networking. When running QEMU manually with `--net`, it defaults to port 1234. Use `--net PORT` to specify a different port. See `doc/ai/DEBUGGING.md` for all QEMU wrapper options.
+**Network port.** Both system tests and `--net` without an explicit port use dynamic port allocation. Use `--net PORT` to specify a fixed port. See `doc/ai/DEBUGGING.md` for all QEMU wrapper options.

--- a/doc/ai/DEBUGGING.md
+++ b/doc/ai/DEBUGGING.md
@@ -164,7 +164,7 @@ The `./qemu_wrapper.sh` script provides flags for debugging:
 
 | Flag | Description |
 |------|-------------|
-| `--gdb` | Enable GDB server on port 1234 |
+| `--gdb [PORT]` | Enable GDB server (default: dynamic port, written to `.gdb-port`) |
 | `--wait` | Pause CPU until GDB attaches |
 | `--log` | Log QEMU events to `/tmp/sentientos.log` |
 | `--net [PORT]` | Enable VirtIO network (default: dynamic port) |
@@ -173,7 +173,7 @@ The `./qemu_wrapper.sh` script provides flags for debugging:
 
 Flags are set in `.cargo/config.toml` for `just run`.
 
-**Note:** When `--net` is used without a port argument, a dynamic port is allocated automatically, allowing multiple QEMU instances to run simultaneously.
+**Note:** When `--net` or `--gdb` is used without a port argument, a dynamic port is allocated automatically, allowing multiple QEMU instances to run simultaneously. The GDB port is written to `.gdb-port` in the project root.
 
 ### Manual GDB
 
@@ -184,7 +184,7 @@ cargo run --release -- --wait
 
 Terminal 2:
 ```bash
-pwndbg -ex "target remote :1234" target/riscv64gc-unknown-none-elf/release/kernel
+pwndbg -ex "target remote :$(cat .gdb-port)" target/riscv64gc-unknown-none-elf/release/kernel
 ```
 
 ### Useful GDB Commands

--- a/doc/ai/DEBUGGING.md
+++ b/doc/ai/DEBUGGING.md
@@ -167,13 +167,13 @@ The `./qemu_wrapper.sh` script provides flags for debugging:
 | `--gdb` | Enable GDB server on port 1234 |
 | `--wait` | Pause CPU until GDB attaches |
 | `--log` | Log QEMU events to `/tmp/sentientos.log` |
-| `--net [PORT]` | Enable VirtIO network (default port 1234) |
+| `--net [PORT]` | Enable VirtIO network (default: dynamic port) |
 | `--smp` | Enable all CPU cores |
 | `--capture` | Capture network traffic to `network.pcap` |
 
 Flags are set in `.cargo/config.toml` for `just run`.
 
-**Note:** When running manually with `--net` without a port argument, only one QEMU instance can run at a time due to port 1234 conflict. System tests use dynamic port allocation to avoid this.
+**Note:** When `--net` is used without a port argument, a dynamic port is allocated automatically, allowing multiple QEMU instances to run simultaneously.
 
 ### Manual GDB
 

--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,7 @@
           pkgs.qemu
           pkgs.cargo-nextest
           pkgs.just
+          pkgs.python3
           rustToolchain
           riscv-toolchain.buildPackages.gcc
           riscv-toolchain.buildPackages.binutils

--- a/justfile
+++ b/justfile
@@ -61,6 +61,7 @@ fetch-deps:
     cargo fetch --manifest-path ./system-tests/Cargo.toml
 
 attach:
+    @test -f .gdb-port || { echo "Error: .gdb-port not found. Is QEMU running with --gdb?"; exit 1; }
     {{gdb}} -ex "target remote :$(cat .gdb-port)" $(pwd)/target/riscv64gc-unknown-none-elf/release/kernel
 
 debug: build

--- a/justfile
+++ b/justfile
@@ -61,16 +61,16 @@ fetch-deps:
     cargo fetch --manifest-path ./system-tests/Cargo.toml
 
 attach:
-    {{gdb}} -ex "target remote :1234" $(pwd)/target/riscv64gc-unknown-none-elf/release/kernel
+    {{gdb}} -ex "target remote :$(cat .gdb-port)" $(pwd)/target/riscv64gc-unknown-none-elf/release/kernel
 
 debug: build
-    tmux new-session -d '{{debugReleaseCommand}}' \; split-window -v '{{gdb}} -ex "target remote :1234" $(pwd)/target/riscv64gc-unknown-none-elf/release/kernel' \; attach
-
-debuguf BIN FUNC: build
-    tmux new-session -d '{{debugReleaseCommand}}' \; split-window -v '{{gdb}} -ex "target remote :1234" -ex "hbreak {{FUNC}}" -ex "c" $(pwd)/kernel/compiled_userspace/{{BIN}}'\; attach
+    tmux new-session -d '{{debugReleaseCommand}}' \; split-window -v 'while [ ! -f .gdb-port ]; do sleep 0.1; done; {{gdb}} -ex "target remote :$(cat .gdb-port)" $(pwd)/target/riscv64gc-unknown-none-elf/release/kernel' \; attach
 
 debugf FUNC: build
-    tmux new-session -d '{{debugReleaseCommand}}' \; split-window -v '{{gdb}} -ex "target remote :1234" -ex "hbreak {{FUNC}}" -ex "c" $(pwd)/target/riscv64gc-unknown-none-elf/release/kernel'\; attach
+    tmux new-session -d '{{debugReleaseCommand}}' \; split-window -v 'while [ ! -f .gdb-port ]; do sleep 0.1; done; {{gdb}} -ex "target remote :$(cat .gdb-port)" -ex "hbreak {{FUNC}}" -ex "c" $(pwd)/target/riscv64gc-unknown-none-elf/release/kernel' \; attach
+
+debuguf BIN FUNC: build
+    tmux new-session -d '{{debugReleaseCommand}}' \; split-window -v 'while [ ! -f .gdb-port ]; do sleep 0.1; done; {{gdb}} -ex "target remote :$(cat .gdb-port)" -ex "hbreak {{FUNC}}" -ex "c" $(pwd)/kernel/compiled_userspace/{{BIN}}' \; attach
 
 disassm: build
     riscv64-unknown-linux-musl-objdump -d --demangle --disassembler-color=on visualize-jumps=extended-color target/riscv64gc-unknown-none-elf/release/kernel

--- a/qemu_wrapper.sh
+++ b/qemu_wrapper.sh
@@ -4,6 +4,8 @@ set -e
 
 cd "$(dirname "$0")"
 
+rm -f .gdb-port
+
 QEMU_CMD="qemu-system-riscv64 \
     -machine virt \
     -cpu rv64 \

--- a/qemu_wrapper.sh
+++ b/qemu_wrapper.sh
@@ -29,7 +29,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --gdb          Let qemu listen on :1234 for gdb connections"
             echo "  --log          Log qemu events to /tmp/sentientos.log"
             echo "  --capture      Capture network traffic into network.pcap"
-            echo "  --net PORT     Enable network card with host port PORT (default: 1234)"
+            echo "  --net [PORT]   Enable network card with host port PORT (default: dynamic)"
             echo "  -h, --help     Show this help message"
             echo "  --wait         Wait cpu until gdb is attached"
             exit 0
@@ -44,7 +44,7 @@ while [[ $# -gt 0 ]]; do
                 NET_PORT="$1"
                 shift
             else
-                NET_PORT="1234"
+                NET_PORT=$(python3 -c "import socket; s=socket.socket(socket.AF_INET, socket.SOCK_DGRAM); s.bind(('127.0.0.1', 0)); print(s.getsockname()[1]); s.close()")
             fi
             QEMU_CMD+=" -netdev user,id=netdev1,hostfwd=udp::${NET_PORT}-:1234 -device virtio-net-pci,netdev=netdev1"
             ;;
@@ -80,5 +80,9 @@ QEMU_CMD+=" -kernel $KERNEL_PATH"
 
 # Execute the QEMU command
 echo "Executing: $QEMU_CMD"
+
+if [[ -n "$NET_PORT" ]]; then
+    echo "Network host port: $NET_PORT" >&2
+fi
 
 exec bash -c "$QEMU_CMD"


### PR DESCRIPTION
## Summary
- **Dynamic network port** (`--net`): Allocates a free UDP port automatically, allowing multiple QEMU instances with networking simultaneously
- **Dynamic GDB port** (`--gdb`): Allocates a free TCP port automatically (replacing hardcoded `-s` / port 1234), written to `.gdb-port` so `just attach`/`just debug` can read it
- **clock_nanosleep**: Implements syscall nr 115 and fixes `tv_nsec=999999999` validation in both nanosleep and clock_nanosleep
- **Nix flake update**: Updates inputs and Rust nightly to 2026-02-07, adds python3 for dynamic port allocation

## Test plan
- [ ] `just run` prints dynamic GDB and network ports to stderr, creates `.gdb-port`
- [ ] Two `just run` in separate worktrees succeed simultaneously
- [ ] `just attach` reads `.gdb-port` and connects
- [ ] `just debug` tmux session works (GDB pane waits for `.gdb-port`)
- [ ] `just system-test` passes

Generated with [Claude Code](https://claude.com/claude-code)