### PR TITLE
fix: Prevent duplicate CI runs on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: ci
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- Only trigger CI workflow on push to main branch
- Prevents duplicate runs when both push and pull_request events fire for PR commits

## Details
Previously, the CI workflow triggered on both `push` and `pull_request` events without branch restrictions, causing duplicate runs for every PR commit.

Now it only runs on:
- Direct pushes to `main` (post-merge)
- All pull requests (via `pull_request` event)

This eliminates redundant CI runs while maintaining full test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)