### PR TITLE
Add CPU ownership tracking to Spinlock for deadlock detection

### DIFF
--- a/kernel/src/klibc/mmio.rs
+++ b/kernel/src/klibc/mmio.rs
@@ -180,7 +180,7 @@ mod tests {
         let mut value = get_test_data();
 
         unsafe {
-            QEMU_UART.disarm();
+            QEMU_UART.force_unlock();
         }
 
         crate::println!("value at {:p}", &value);

--- a/kernel/src/klibc/spinlock.rs
+++ b/kernel/src/klibc/spinlock.rs
@@ -2,8 +2,13 @@ use core::{
     cell::UnsafeCell,
     fmt::Debug,
     ops::{Deref, DerefMut},
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };
+
+#[cfg(not(test))]
+use crate::cpu::Cpu;
+
+const NO_OWNER: usize = usize::MAX;
 
 #[derive(Debug)]
 pub struct Spinlock<T> {
@@ -13,6 +18,7 @@ pub struct Spinlock<T> {
     // in the future. This is highly unsafe and only useful to
     // unlock the uart spinlock in case of a panic.
     disarmed: AtomicBool,
+    owner_cpu: AtomicUsize,
 }
 
 impl<T> Spinlock<T> {
@@ -21,6 +27,7 @@ impl<T> Spinlock<T> {
             locked: AtomicBool::new(false),
             data: UnsafeCell::new(data),
             disarmed: AtomicBool::new(false),
+            owner_cpu: AtomicUsize::new(NO_OWNER),
         }
     }
 
@@ -34,6 +41,7 @@ impl<T> Spinlock<T> {
             .locked
             .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed);
         if value.is_ok() {
+            self.set_owner();
             let lock = SpinlockGuard { spinlock: self };
             return Some(f(lock));
         }
@@ -44,14 +52,63 @@ impl<T> Spinlock<T> {
         if self.disarmed.load(Ordering::SeqCst) {
             return SpinlockGuard { spinlock: self };
         }
+        self.detect_same_cpu_deadlock();
+        let mut spin_count: u32 = 0;
         while self
             .locked
             .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
             .is_err()
         {
+            spin_count += 1;
+            self.warn_possible_deadlock(spin_count);
             core::hint::spin_loop();
         }
+        self.set_owner();
         SpinlockGuard { spinlock: self }
+    }
+
+    #[cfg(not(test))]
+    fn detect_same_cpu_deadlock(&self) {
+        if self.locked.load(Ordering::Relaxed) {
+            let cpu_id = Cpu::cpu_id();
+            assert_ne!(
+                self.owner_cpu.load(Ordering::Relaxed),
+                cpu_id,
+                "Spinlock deadlock: CPU {cpu_id} tried to re-acquire a lock it already holds"
+            );
+        }
+    }
+
+    #[cfg(test)]
+    fn detect_same_cpu_deadlock(&self) {}
+
+    #[cfg(not(test))]
+    fn warn_possible_deadlock(&self, spin_count: u32) {
+        if spin_count.is_multiple_of(10_000_000) {
+            let cpu_id = Cpu::cpu_id();
+            let owner = self.owner_cpu.load(Ordering::Relaxed);
+            crate::warn!(
+                "Spinlock likely deadlocked: CPU {} waiting for lock held by CPU {} ({} spins)",
+                cpu_id,
+                owner,
+                spin_count
+            );
+        }
+    }
+
+    #[cfg(test)]
+    fn warn_possible_deadlock(&self, _spin_count: u32) {}
+
+    #[cfg(not(test))]
+    fn set_owner(&self) {
+        self.owner_cpu.store(Cpu::cpu_id(), Ordering::Relaxed);
+    }
+
+    #[cfg(test)]
+    fn set_owner(&self) {}
+
+    fn clear_owner(&self) {
+        self.owner_cpu.store(NO_OWNER, Ordering::Relaxed);
     }
 
     #[cfg(test)]
@@ -76,6 +133,7 @@ pub struct SpinlockGuard<'a, T> {
 
 impl<T> Drop for SpinlockGuard<'_, T> {
     fn drop(&mut self) {
+        self.spinlock.clear_owner();
         self.spinlock.locked.store(false, Ordering::Release);
     }
 }
@@ -107,7 +165,7 @@ impl<T: Debug> Debug for SpinlockGuard<'_, T> {
 mod tests {
     use core::sync::atomic::Ordering;
 
-    use super::Spinlock;
+    use super::{NO_OWNER, Spinlock};
     use crate::debug;
 
     #[test_case]
@@ -162,5 +220,22 @@ mod tests {
         debug!("{spinlock:?}");
         let spinlock_guard = spinlock.lock();
         debug!("{spinlock_guard:?}");
+    }
+
+    #[test_case]
+    fn owner_cpu_cleared_after_unlock() {
+        let spinlock = Spinlock::new(42);
+        assert_eq!(spinlock.owner_cpu.load(Ordering::Relaxed), NO_OWNER);
+        {
+            let _lock = spinlock.lock();
+        }
+        assert_eq!(spinlock.owner_cpu.load(Ordering::Relaxed), NO_OWNER);
+    }
+
+    #[test_case]
+    fn try_with_lock_clears_owner() {
+        let spinlock = Spinlock::new(42);
+        spinlock.try_with_lock(|_| {});
+        assert_eq!(spinlock.owner_cpu.load(Ordering::Relaxed), NO_OWNER);
     }
 }

--- a/kernel/src/klibc/spinlock.rs
+++ b/kernel/src/klibc/spinlock.rs
@@ -203,7 +203,8 @@ mod tests {
     #[test_case]
     fn force_unlock_allows_reacquire() {
         let spinlock = Spinlock::new(42);
-        let _lock = spinlock.lock();
+        let lock = spinlock.lock();
+        core::mem::forget(lock);
         unsafe {
             spinlock.force_unlock();
         }

--- a/kernel/src/panic.rs
+++ b/kernel/src/panic.rs
@@ -35,7 +35,7 @@ fn panic(info: &PanicInfo) -> ! {
     }
 
     unsafe {
-        QEMU_UART.disarm();
+        QEMU_UART.force_unlock();
     }
 
     println!("\nKERNEL Panic");


### PR DESCRIPTION
## Summary
- Track which CPU holds each spinlock via an `owner_cpu: AtomicUsize` field
- **Same-CPU recursive lock**: panics immediately with a diagnostic message instead of hanging silently
- **Cross-CPU deadlock warning**: after 10M spins, logs a warning with the owning CPU ID
- **Replace `disarm()` with `force_unlock()`**: removes the permanent disarmed mode and the per-`lock()` `SeqCst` branch; panic handler now force-releases the UART lock once instead of permanently disabling it

## Test plan
- [x] `just clippy` — no warnings
- [x] `just unit-test` — all 88 tests pass including 2 new spinlock tests
- [x] `just system-test` — all 17 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)