### PR TITLE
Fix OOB panic in consume_str and add 25 unit tests

### DIFF
--- a/kernel/src/processes/brk.rs
+++ b/kernel/src/processes/brk.rs
@@ -54,3 +54,42 @@ impl Brk {
         self.brk_current
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Brk;
+
+    #[test_case]
+    fn brk_within_range() {
+        let mut brk = Brk {
+            brk_start: 0x1000,
+            brk_current: 0x1000,
+            brk_end: 0x5000,
+        };
+        assert_eq!(brk.brk(0x2000), 0x2000);
+        assert_eq!(brk.brk(0x4FFF), 0x4FFF);
+    }
+
+    #[test_case]
+    fn brk_out_of_range_returns_current() {
+        let mut brk = Brk {
+            brk_start: 0x1000,
+            brk_current: 0x2000,
+            brk_end: 0x5000,
+        };
+        // Below start
+        assert_eq!(brk.brk(0x0500), 0x2000);
+        // At end (exclusive boundary)
+        assert_eq!(brk.brk(0x5000), 0x2000);
+        // Above end
+        assert_eq!(brk.brk(0x9000), 0x2000);
+    }
+
+    #[test_case]
+    fn brk_empty() {
+        let mut brk = Brk::empty();
+        assert_eq!(brk.brk(0), 0);
+        // brk_end is 1, so 0 is within [0, 1)
+        assert_eq!(brk.brk(0x1000), 0);
+    }
+}


### PR DESCRIPTION
## Summary
- Fix index-out-of-bounds panic in `ConsumableBuffer::consume_str()` when buffer has no null terminator
- Add 11 unit tests for `ConsumableBuffer` (slice consumption, string parsing, alignment, utilities)
- Add 11 unit tests for `PageTableEntry`/`MappingEntry` (bit ops, overlap detection, XWR mode conversion)
- Add 3 unit tests for `Brk` (in-range, out-of-range, empty)
- Total unit tests: 86 → 111

## Test plan
- [x] `just clippy` passes
- [x] `just unit-test` passes (111/111)

🤖 Generated with [Claude Code](https://claude.com/claude-code)