### PR TITLE
Add shell system tests for background execution and invalid programs

### DIFF
--- a/system-tests/src/tests/mod.rs
+++ b/system-tests/src/tests/mod.rs
@@ -3,6 +3,7 @@ mod connect4;
 mod coreutils;
 mod net;
 mod panic;
+mod sesh;
 mod signals;
 mod sleep;
 mod stress;

--- a/system-tests/src/tests/sesh.rs
+++ b/system-tests/src/tests/sesh.rs
@@ -1,0 +1,22 @@
+use crate::infra::qemu::QemuInstance;
+use qemu_infra::PROMPT;
+
+#[tokio::test]
+async fn background_execution() -> anyhow::Result<()> {
+    let mut sentientos = QemuInstance::start().await?;
+    sentientos.write_and_wait_for("sleep 10 &\n", PROMPT).await?;
+    sentientos
+        .write_and_wait_for("prog1\n", "Hello from Prog1")
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn execute_nonexistent_program() -> anyhow::Result<()> {
+    let mut sentientos = QemuInstance::start().await?;
+    let output = sentientos.run_prog("nonexistent").await?;
+    assert!(output.contains("Error executing program"));
+    let output = sentientos.run_prog("prog1").await?;
+    assert_eq!(output, "Hello from Prog1\n");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Add `background_execution` test: runs `sleep 10 &`, verifies prompt returns immediately, then runs `prog1` to prove the shell stays responsive
- Add `execute_nonexistent_program` test: runs a non-existent program, asserts error message, verifies shell recovers

## Test plan
- [x] Both new tests pass individually
- [x] Full `just system-test` suite passes (19/19)
- [x] `just clippy` clean


Generated with [Claude Code](https://claude.com/claude-code)