### PR TITLE
refactor: Replace all .unwrap() with .expect() and deny lint

### DIFF
--- a/kernel/src/debugging/unwinder.rs
+++ b/kernel/src/debugging/unwinder.rs
@@ -94,7 +94,10 @@ impl<'a> Unwinder<'a> {
                 }
                 Instruction::Restore { register } => {
                     debug!("Restre(register={})", *register);
-                    let first_rule = self.rows.first().unwrap();
+                    let first_rule = self
+                        .rows
+                        .first()
+                        .expect("Rows must not be empty during Restore");
                     current_row.register_rules[*register as usize] =
                         first_rule.register_rules[*register as usize];
                 }

--- a/kernel/src/klibc/util.rs
+++ b/kernel/src/klibc/util.rs
@@ -318,7 +318,7 @@ mod tests {
         // Allocate with Header alignment so interpret_as's is_aligned() check is guaranteed.
         let layout =
             alloc::alloc::Layout::from_size_align(total_len, core::mem::align_of::<Header>())
-                .unwrap();
+                .expect("Layout must be valid");
         let buf = unsafe {
             let ptr = alloc::alloc::alloc_zeroed(layout);
             core::slice::from_raw_parts_mut(ptr, total_len)

--- a/kernel/src/logging/mod.rs
+++ b/kernel/src/logging/mod.rs
@@ -42,14 +42,17 @@ pub fn _print(args: fmt::Arguments) {
     {
         use std::io::Write;
         let mut stdout = std::io::stdout().lock();
-        stdout.write_fmt(args).unwrap();
-        stdout.flush().unwrap();
+        stdout.write_fmt(args).expect("Failed to write to stdout");
+        stdout.flush().expect("Failed to flush stdout");
     }
 
     #[cfg(not(miri))]
     {
         use crate::io::uart;
         use core::fmt::Write;
-        uart::QEMU_UART.lock().write_fmt(args).unwrap();
+        uart::QEMU_UART
+            .lock()
+            .write_fmt(args)
+            .expect("Failed to write to UART");
     }
 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -5,6 +5,7 @@
 #![cfg_attr(miri, allow(unused_macros))]
 #![cfg_attr(test, allow(dead_code))]
 #![cfg_attr(test, allow(unused_imports))]
+#![deny(clippy::unwrap_used)]
 #![feature(nonzero_ops)]
 #![feature(custom_test_frameworks)]
 #![feature(assert_matches)]

--- a/kernel/src/memory/heap.rs
+++ b/kernel/src/memory/heap.rs
@@ -374,7 +374,12 @@ mod test {
             ptr.write(0x42);
         };
         let heap = heap.inner.lock();
-        let free_block = unsafe { heap.genesis_block.next.unwrap().as_ref() };
+        let free_block = unsafe {
+            heap.genesis_block
+                .next
+                .expect("Free list must have a block")
+                .as_ref()
+        };
         assert!(free_block.next.is_none());
         assert_eq!(
             free_block.size.total_size(),
@@ -398,7 +403,12 @@ mod test {
         };
 
         let heap = heap.inner.lock();
-        let free_block = unsafe { heap.genesis_block.next.unwrap().as_ref() };
+        let free_block = unsafe {
+            heap.genesis_block
+                .next
+                .expect("Free list must have a block")
+                .as_ref()
+        };
         assert!(free_block.next.is_none());
         assert_eq!(
             free_block.size.total_size(),
@@ -417,10 +427,20 @@ mod test {
 
         dealloc(&heap, ptr);
         let heap = heap.inner.lock();
-        let free_block1 = unsafe { heap.genesis_block.next.unwrap().as_ref() };
+        let free_block1 = unsafe {
+            heap.genesis_block
+                .next
+                .expect("Free list must have a block after dealloc")
+                .as_ref()
+        };
         assert_eq!(free_block1.size.total_size(), FreeBlock::MINIMUM_SIZE);
 
-        let free_block2 = unsafe { free_block1.next.unwrap().as_ref() };
+        let free_block2 = unsafe {
+            free_block1
+                .next
+                .expect("Free list must have a second block")
+                .as_ref()
+        };
         assert!(free_block2.next.is_none());
         assert_eq!(
             free_block2.size.total_size(),
@@ -468,7 +488,13 @@ mod test {
         }
 
         let heap_lock = heap.inner.lock();
-        let free_block = unsafe { heap_lock.genesis_block.next.unwrap().as_ref() };
+        let free_block = unsafe {
+            heap_lock
+                .genesis_block
+                .next
+                .expect("Free list must have a block after partial realloc")
+                .as_ref()
+        };
         assert!(free_block.next.is_none());
         // Because we use the page allocator directly there should be only one page allocated to the heap
         assert_eq!(

--- a/kernel/src/pci/allocator.rs
+++ b/kernel/src/pci/allocator.rs
@@ -77,8 +77,12 @@ mod tests {
     #[test_case]
     fn alignment() {
         let mut allocator = init_allocator(8192);
-        let _ = allocator.allocate(3).unwrap();
-        let allocation = allocator.allocate(4096).unwrap();
+        let _ = allocator
+            .allocate(3)
+            .expect("Small allocation must succeed");
+        let allocation = allocator
+            .allocate(4096)
+            .expect("Page-sized allocation must succeed");
         assert!(
             allocation.cpu_address.is_multiple_of(4096),
             "cpu address must be properly aligned"

--- a/kernel/src/processes/process.rs
+++ b/kernel/src/processes/process.rs
@@ -268,16 +268,18 @@ mod tests {
     #[test_case]
     fn create_process_from_elf() {
         let elf = ElfFile::parse(PROG1).expect("Cannot parse elf file");
-        let _process = Thread::from_elf(&elf, "prog1", &[]).unwrap();
+        let _process = Thread::from_elf(&elf, "prog1", &[]).expect("ELF loading must succeed");
     }
 
     #[test_case]
     fn mmap_process() {
         let elf = ElfFile::parse(PROG1).expect("Cannot parse elf file");
 
-        let process_ref = Thread::from_elf(&elf, "prog1", &[]).unwrap();
+        let process_ref = Thread::from_elf(&elf, "prog1", &[]).expect("ELF loading must succeed");
 
-        let thread = Arc::into_inner(process_ref).unwrap().into_inner();
+        let thread = Arc::into_inner(process_ref)
+            .expect("Must be sole owner")
+            .into_inner();
         let process = thread.process();
         let mut process = process.lock();
 


### PR DESCRIPTION
## Summary
- Replace all 38 `.unwrap()` calls in `kernel/src/` with `.expect("descriptive message")` for better panic diagnostics
- Add `#![deny(clippy::unwrap_used)]` crate-level lint to prevent future `.unwrap()` usage
- Continues the `FdTable::allocate` refactoring from earlier commits on this branch

## Test plan
- [x] `just clippy` passes with zero warnings (including the new lint)
- [x] `just system-test` — all 19 tests pass
- [x] `grep -r '.unwrap()' kernel/src/` returns zero results (only a commented-out line remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)