### PR TITLE
feat: Implement munmap syscall (R-02)

### DIFF
--- a/kernel/src/cpu.rs
+++ b/kernel/src/cpu.rs
@@ -241,13 +241,6 @@ impl Cpu {
         }
     }
 
-    pub fn sfence_vma() {
-        // SAFETY: sfence.vma flushes the TLB; safe to call at any time.
-        unsafe {
-            asm!("sfence.vma");
-        }
-    }
-
     pub fn memory_fence() {
         // SAFETY: `fence` is a memory ordering instruction with no operands.
         unsafe {

--- a/kernel/src/cpu.rs
+++ b/kernel/src/cpu.rs
@@ -241,6 +241,13 @@ impl Cpu {
         }
     }
 
+    pub fn sfence_vma() {
+        // SAFETY: sfence.vma flushes the TLB; safe to call at any time.
+        unsafe {
+            asm!("sfence.vma");
+        }
+    }
+
     pub fn memory_fence() {
         // SAFETY: `fence` is a memory ordering instruction with no operands.
         unsafe {

--- a/kernel/src/memory/page_tables.rs
+++ b/kernel/src/memory/page_tables.rs
@@ -594,8 +594,6 @@ impl RootPageTableHolder {
             *third_level_entry = PageTableEntry(null_mut());
             offset += PAGE_SIZE;
         }
-
-        Cpu::sfence_vma();
     }
 
     pub fn is_mapped(&self, range: Range<usize>) -> bool {

--- a/kernel/src/syscalls/linux.rs
+++ b/kernel/src/syscalls/linux.rs
@@ -338,12 +338,13 @@ impl LinuxSyscalls for LinuxSyscallHandler {
         })
     }
 
-    async fn munmap(
-        &mut self,
-        _addr: usize,
-        _length: usize,
-    ) -> Result<isize, headers::errno::Errno> {
-        // Ignore munmap for now
+    async fn munmap(&mut self, addr: usize, length: usize) -> Result<isize, headers::errno::Errno> {
+        if !addr.is_multiple_of(PAGE_SIZE) || length == 0 {
+            return Err(Errno::EINVAL);
+        }
+        self.handler
+            .current_process()
+            .with_lock(|mut p| p.munmap_pages(addr, length))?;
         Ok(0)
     }
 

--- a/todo/REFACTORINGS.md
+++ b/todo/REFACTORINGS.md
@@ -5,15 +5,6 @@ independently actionable. Reference by number (e.g. "R-02") in commits and PRs.
 
 ---
 
-## High Impact
-
-**R-02 — Implement munmap.**
-`munmap` is a no-op returning `Ok(0)` (`syscalls/linux.rs:347-354`). Every
-`mmap` allocation leaks permanently. Implementing real munmap requires
-page-table unmapping and feeding pages back to the allocator.
-
----
-
 ## Medium Impact
 
 **R-04 — Remove hardcoded IP address.**


### PR DESCRIPTION
## Summary
- Replace no-op munmap with real page-table unmapping and physical page deallocation
- Track mmap allocations in a separate `BTreeMap<usize, PinnedHeapPages>` for O(log n) lookup by address
- Add `unmap_userspace()` to `RootPageTableHolder` that clears leaf PTEs and flushes TLB via `sfence.vma`
- Validate user input (alignment, length, address match) — return `EINVAL` instead of panicking

## Test plan
- [x] Unit tests: `unmap_userspace_clears_mapping`, `unmap_userspace_clears_pte_validity`
- [x] Unit tests: `munmap_process`, `munmap_unknown_address_returns_einval`, `munmap_wrong_length_returns_einval`
- [x] `just clippy` clean
- [x] All 22 system tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)