### PR TITLE
Migrate sys_read_input to fcntl + O_NONBLOCK + read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ name = "userspace"
 version = "0.1.0"
 dependencies = [
  "common",
+ "libc",
 ]
 
 [[package]]

--- a/common/src/syscalls/definition.rs
+++ b/common/src/syscalls/definition.rs
@@ -19,7 +19,6 @@ scalar_enum! {
 }
 
 syscalls!(
-    sys_read_input() -> Option<u8>;
     sys_execute<'a>(name: &'a str, args: &'a [&'a str]) -> Result<Tid, SysExecuteError>;
     sys_wait(tid: Tid) -> Result<Tid, SysWaitError>;
     sys_open_udp_socket(port: u16) -> Result<UDPDescriptor, SysSocketError>;

--- a/doc/ai/SYSCALLS.md
+++ b/doc/ai/SYSCALLS.md
@@ -42,6 +42,7 @@ fn handle_syscall() {
 | brk | brk | Adjust heap break |
 | close | fd | Close file descriptor |
 | exit_group | status | Exit process |
+| fcntl | fd, cmd, arg | File descriptor control (F_GETFL/F_SETFL, O_NONBLOCK) |
 | gettid | | Get thread ID |
 | ioctl | fd, op | Device control (+ SentientOS extensions) |
 | mmap | addr, len, prot, flags, fd, off | Map memory |
@@ -123,7 +124,6 @@ Custom syscalls with bit 63 set for synchronous execution:
 
 ```rust
 impl KernelSyscalls for SyscallHandler {
-    fn sys_read_input(&mut self) -> Option<u8>;
     fn sys_execute(&mut self, name, args) -> Result<Tid, SysExecuteError>;
     fn sys_wait(&mut self, tid) -> Result<Tid, SysWaitError>;
     fn sys_open_udp_socket(&mut self, port) -> Result<UDPDescriptor, SysSocketError>;

--- a/headers/build.rs
+++ b/headers/build.rs
@@ -76,6 +76,7 @@ fn default_bindgen_builder() -> bindgen::Builder {
 
 fn generate_syscall_types(out_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let bindings = default_bindgen_builder()
+        .header("linux_headers/include/asm-generic/fcntl.h")
         .header("linux_headers/include/asm-generic/ioctls.h")
         .header("linux_headers/include/asm-generic/poll.h")
         .header("linux_headers/include/asm-generic/signal.h")

--- a/kernel/src/io/stdin_buf.rs
+++ b/kernel/src/io/stdin_buf.rs
@@ -32,10 +32,6 @@ impl StdinBuffer {
         }
     }
 
-    pub fn pop(&mut self) -> Option<u8> {
-        self.data.pop_front()
-    }
-
     pub fn get(&mut self, count: usize) -> Vec<u8> {
         let actual_count = min(self.data.len(), count);
 
@@ -96,9 +92,7 @@ mod tests {
         stdin.push(43);
         stdin.push(44);
 
-        assert_eq!(stdin.pop(), Some(42));
-        assert_eq!(stdin.pop(), Some(43));
-        assert_eq!(stdin.pop(), Some(44));
+        assert_eq!(stdin.get(3), &[42, 43, 44]);
     }
 
     #[test_case]

--- a/kernel/src/processes/fd_table.rs
+++ b/kernel/src/processes/fd_table.rs
@@ -19,7 +19,7 @@ impl FdFlags {
     }
 
     pub fn from_raw(raw: i32) -> Self {
-        Self(raw)
+        Self(raw & (O_NONBLOCK as i32))
     }
 }
 

--- a/kernel/src/processes/fd_table.rs
+++ b/kernel/src/processes/fd_table.rs
@@ -11,7 +11,7 @@ pub struct FdFlags(i32);
 
 impl FdFlags {
     pub fn is_nonblocking(self) -> bool {
-        self.0 & O_NONBLOCK as i32 != 0
+        (self.0 & O_NONBLOCK as i32) != 0
     }
 
     pub fn as_raw(self) -> i32 {

--- a/kernel/src/syscalls/handler.rs
+++ b/kernel/src/syscalls/handler.rs
@@ -10,7 +10,6 @@ use common::{
 use crate::{
     cpu::Cpu,
     debug,
-    io::stdin_buf::STDIN_BUFFER,
     net::{self, arp, udp::UdpHeader},
     processes::{process::ProcessRef, thread::ThreadRef},
 };
@@ -59,10 +58,6 @@ impl SyscallHandler {
 
 impl KernelSyscalls for SyscallHandler {
     type ArgWrapper<T: SyscallArgument> = UserspaceArgument<T>;
-
-    fn sys_read_input(&mut self) -> Option<u8> {
-        STDIN_BUFFER.lock().pop()
-    }
 
     fn sys_execute<'a>(
         &mut self,

--- a/kernel/src/syscalls/linux.rs
+++ b/kernel/src/syscalls/linux.rs
@@ -20,9 +20,9 @@ use headers::{
     errno::Errno,
     syscall_types::{
         _NSIG, CLOCK_MONOTONIC, CLOCK_REALTIME, F_GETFL, F_SETFL, MAP_ANONYMOUS, MAP_FIXED,
-        MAP_PRIVATE, O_NONBLOCK, PROT_EXEC, PROT_NONE, PROT_READ, PROT_WRITE, SIG_BLOCK,
-        SIG_SETMASK, SIG_UNBLOCK, SIGKILL, SIGSTOP, TIOCGWINSZ, iovec, pollfd, sigaction, sigset_t,
-        stack_t, timespec,
+        MAP_PRIVATE, PROT_EXEC, PROT_NONE, PROT_READ, PROT_WRITE, SIG_BLOCK, SIG_SETMASK,
+        SIG_UNBLOCK, SIGKILL, SIGSTOP, TIOCGWINSZ, iovec, pollfd, sigaction, sigset_t, stack_t,
+        timespec,
     },
 };
 
@@ -444,7 +444,7 @@ impl LinuxSyscalls for LinuxSyscallHandler {
             }
             F_SETFL => {
                 let raw = i32::try_from(arg).map_err(|_| Errno::EINVAL)?;
-                let flags = FdFlags::from_raw(raw & (O_NONBLOCK as i32));
+                let flags = FdFlags::from_raw(raw);
                 self.handler
                     .current_process()
                     .with_lock(|mut p| p.fd_table_mut().set_flags(fd, flags))?;

--- a/kernel/src/syscalls/linux.rs
+++ b/kernel/src/syscalls/linux.rs
@@ -444,7 +444,7 @@ impl LinuxSyscalls for LinuxSyscallHandler {
             }
             F_SETFL => {
                 let raw = i32::try_from(arg).map_err(|_| Errno::EINVAL)?;
-                let flags = FdFlags::from_raw(raw & O_NONBLOCK as i32);
+                let flags = FdFlags::from_raw(raw & (O_NONBLOCK as i32));
                 self.handler
                     .current_process()
                     .with_lock(|mut p| p.fd_table_mut().set_flags(fd, flags))?;

--- a/kernel/src/syscalls/linux.rs
+++ b/kernel/src/syscalls/linux.rs
@@ -3,7 +3,11 @@ use crate::{
     klibc::util::UsizeExt,
     memory::{PAGE_SIZE, page_tables::XWRMode},
     print, println,
-    processes::{fd_table::FileDescriptor, process::ProcessRef, timer},
+    processes::{
+        fd_table::{FdFlags, FileDescriptor},
+        process::ProcessRef,
+        timer,
+    },
     syscalls::{handler::SyscallHandler, macros::linux_syscalls},
 };
 use alloc::vec::Vec;
@@ -15,9 +19,10 @@ use core::ffi::{c_int, c_uint, c_ulong};
 use headers::{
     errno::Errno,
     syscall_types::{
-        _NSIG, CLOCK_MONOTONIC, CLOCK_REALTIME, MAP_ANONYMOUS, MAP_FIXED, MAP_PRIVATE, PROT_EXEC,
-        PROT_NONE, PROT_READ, PROT_WRITE, SIG_BLOCK, SIG_SETMASK, SIG_UNBLOCK, SIGKILL, SIGSTOP,
-        TIOCGWINSZ, iovec, pollfd, sigaction, sigset_t, stack_t, timespec,
+        _NSIG, CLOCK_MONOTONIC, CLOCK_REALTIME, F_GETFL, F_SETFL, MAP_ANONYMOUS, MAP_FIXED,
+        MAP_PRIVATE, O_NONBLOCK, PROT_EXEC, PROT_NONE, PROT_READ, PROT_WRITE, SIG_BLOCK,
+        SIG_SETMASK, SIG_UNBLOCK, SIGKILL, SIGSTOP, TIOCGWINSZ, iovec, pollfd, sigaction, sigset_t,
+        stack_t, timespec,
     },
 };
 
@@ -25,6 +30,7 @@ linux_syscalls! {
     SYSCALL_NR_BRK => brk(brk: c_ulong);
     SYSCALL_NR_CLOSE => close(fd: c_int);
     SYSCALL_NR_EXIT_GROUP => exit_group(status: c_int);
+    SYSCALL_NR_FCNTL => fcntl(fd: c_int, cmd: c_int, arg: c_ulong);
     SYSCALL_NR_GETPPID => getppid();
     SYSCALL_NR_GETTID => gettid();
     SYSCALL_NR_IOCTL => ioctl(fd: c_int, op: c_uint);
@@ -54,13 +60,21 @@ impl LinuxSyscalls for LinuxSyscallHandler {
         buf: LinuxUserspaceArg<*mut u8>,
         count: usize,
     ) -> Result<isize, headers::errno::Errno> {
-        let descriptor = self
+        let (descriptor, flags) = self
             .handler
             .current_process()
-            .with_lock(|p| p.fd_table().get(fd).cloned())
+            .with_lock(|p| {
+                p.fd_table()
+                    .get(fd)
+                    .map(|e| (e.descriptor.clone(), e.flags))
+            })
             .ok_or(Errno::EBADF)?;
 
-        let data = descriptor.read(count).await?;
+        let data = if flags.is_nonblocking() {
+            descriptor.try_read(count)?
+        } else {
+            descriptor.read(count).await?
+        };
         assert!(data.len() <= count, "Read more than requested");
         buf.write_slice(&data)?;
 
@@ -76,7 +90,7 @@ impl LinuxSyscalls for LinuxSyscallHandler {
         let descriptor = self
             .handler
             .current_process()
-            .with_lock(|p| p.fd_table().get(fd).cloned())
+            .with_lock(|p| p.fd_table().get(fd).map(|e| e.descriptor.clone()))
             .ok_or(Errno::EBADF)?;
 
         let data = buf.validate_slice(count)?;
@@ -125,7 +139,7 @@ impl LinuxSyscalls for LinuxSyscallHandler {
         for pfd in &poll_fds {
             self.handler
                 .current_process()
-                .with_lock(|p| p.fd_table().get(pfd.fd).cloned())
+                .with_lock(|p| p.fd_table().get(pfd.fd).map(|e| e.descriptor.clone()))
                 .ok_or(Errno::EBADF)?;
             assert_eq!(
                 pfd.events, 0,
@@ -356,7 +370,7 @@ impl LinuxSyscalls for LinuxSyscallHandler {
         let descriptor = self
             .handler
             .current_process()
-            .with_lock(|p| p.fd_table().get(fd).cloned())
+            .with_lock(|p| p.fd_table().get(fd).map(|e| e.descriptor.clone()))
             .ok_or(Errno::EBADF)?;
 
         match descriptor {
@@ -386,7 +400,7 @@ impl LinuxSyscalls for LinuxSyscallHandler {
         let descriptor = self
             .handler
             .current_process()
-            .with_lock(|p| p.fd_table().get(fd).cloned())
+            .with_lock(|p| p.fd_table().get(fd).map(|e| e.descriptor.clone()))
             .ok_or(Errno::EBADF)?;
 
         let iov = iov.validate_slice(usize::try_from(iovcnt).map_err(|_| Errno::EINVAL)?)?;
@@ -412,6 +426,32 @@ impl LinuxSyscalls for LinuxSyscallHandler {
             .current_process()
             .with_lock(|mut p| p.fd_table_mut().close(fd))?;
         Ok(0)
+    }
+
+    async fn fcntl(
+        &mut self,
+        fd: c_int,
+        cmd: c_int,
+        arg: c_ulong,
+    ) -> Result<isize, headers::errno::Errno> {
+        match cmd.cast_unsigned() {
+            F_GETFL => {
+                let flags = self
+                    .handler
+                    .current_process()
+                    .with_lock(|p| p.fd_table().get_flags(fd))?;
+                Ok(flags.as_raw() as isize)
+            }
+            F_SETFL => {
+                let raw = i32::try_from(arg).map_err(|_| Errno::EINVAL)?;
+                let flags = FdFlags::from_raw(raw & O_NONBLOCK as i32);
+                self.handler
+                    .current_process()
+                    .with_lock(|mut p| p.fd_table_mut().set_flags(fd, flags))?;
+                Ok(0)
+            }
+            _ => Err(Errno::EINVAL),
+        }
     }
 
     async fn getppid(&mut self) -> Result<isize, headers::errno::Errno> {

--- a/kernel/src/syscalls/validator.rs
+++ b/kernel/src/syscalls/validator.rs
@@ -36,7 +36,7 @@ impl Validatable<SharedAssignedSocket> for UserspaceArgument<UDPDescriptor> {
         let fd = i32::try_from(self.inner.get()).expect("fd fits in i32");
         let descriptor = handler
             .current_process()
-            .with_lock(|p| p.fd_table().get(fd).cloned())
+            .with_lock(|p| p.fd_table().get(fd).map(|e| e.descriptor.clone()))
             .ok_or(SysSocketError::InvalidDescriptor)?;
         match descriptor {
             FileDescriptor::UdpSocket(socket) => Ok(socket),

--- a/userspace/Cargo.toml
+++ b/userspace/Cargo.toml
@@ -12,3 +12,4 @@ forced-target = "riscv64gc-unknown-linux-musl"
 
 [dependencies]
 common = { path = "../common" }
+libc = "0.2"

--- a/userspace/src/bin/udp.rs
+++ b/userspace/src/bin/udp.rs
@@ -1,7 +1,5 @@
 use std::io::{Write, stdout};
 
-// use alloc::string::String;
-use common::syscalls::sys_read_input;
 use userspace::net::UdpSocket;
 
 extern crate alloc;
@@ -13,6 +11,8 @@ const DELETE: u8 = 127;
 fn main() {
     println!("Hello from the udp receiver");
     println!("Listening on {PORT}");
+
+    unsafe { libc::fcntl(0, libc::F_SETFL, libc::O_NONBLOCK) };
 
     let mut socket = UdpSocket::try_open(PORT).expect("Socket must be openable.");
     let mut input = String::new();
@@ -27,11 +27,11 @@ fn main() {
             let _ = stdout().flush();
         }
 
-        if let Some(c) = sys_read_input() {
+        let mut c = 0u8;
+        let ret = unsafe { libc::read(0, &mut c as *mut u8 as *mut libc::c_void, 1) };
+        if ret == 1 {
             match c {
                 b'\r' | b'\n' => {
-                    // Carriage return
-                    // Send data
                     println!();
                     input.push(b'\n' as char);
                     socket.transmit(input.as_bytes());

--- a/userspace/src/bin/udp.rs
+++ b/userspace/src/bin/udp.rs
@@ -12,7 +12,10 @@ fn main() {
     println!("Hello from the udp receiver");
     println!("Listening on {PORT}");
 
-    unsafe { libc::fcntl(0, libc::F_SETFL, libc::O_NONBLOCK) };
+    assert_eq!(
+        unsafe { libc::fcntl(0, libc::F_SETFL, libc::O_NONBLOCK) },
+        0
+    );
 
     let mut socket = UdpSocket::try_open(PORT).expect("Socket must be openable.");
     let mut input = String::new();


### PR DESCRIPTION
## Summary
- Implement `fcntl` syscall with `F_GETFL`/`F_SETFL` support for `O_NONBLOCK`
- Add per-fd flags tracking via `FdFlags` newtype in `FdTable`
- Make `read` syscall return `EAGAIN` on stdin when `O_NONBLOCK` is set and no data is available
- Update `udp.rs` to use `libc::fcntl` + `libc::read` instead of custom `sys_read_input`
- Remove `sys_read_input` from common and kernel

## Test plan
- [x] `just clippy` passes with no warnings
- [x] All 22 system tests pass (including UDP test that exercises the new codepath)
- [x] Blocking read behavior unchanged for shell/sesh (no `O_NONBLOCK` set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)