### PR TITLE
refactor: Replace separate zombie tracking with Zombie(u8) thread state

### DIFF
--- a/kernel/src/interrupts/trap.rs
+++ b/kernel/src/interrupts/trap.rs
@@ -101,6 +101,11 @@ fn check_thread_ownership_and_reschedule_if_needed(trap_frame: TrapFrame) -> boo
                     t.set_program_counter(sepc);
                     true
                 }
+                ThreadState::Zombie(_) => {
+                    // Thread was killed by another CPU while we were in a syscall.
+                    // No need to save state — just reschedule.
+                    true
+                }
             }
         });
 


### PR DESCRIPTION
Zombie processes now stay in the process table with ThreadState::Zombie(exit_code)
instead of being moved to a separate zombies BTreeMap. This simplifies the
process table by removing ZombieEntry and the duplicate reparenting logic.

Key changes:
- Add Zombie(u8) variant to ThreadState
- Remove ZombieEntry struct and zombies BTreeMap from ProcessTable
- kill() sets Zombie state instead of removing thread from table
- take_zombie() finds and removes zombie threads from the threads map
- is_empty() excludes zombie threads
- get_highest_tid_without() skips zombie threads

https://claude.ai/code/session_01TbUJBGeds9vznXiQA7uaie