### PR TITLE
refactor: Deduplicate MCP server code and remove redundant run_program tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,6 @@ just mcp-server                    # Build
 | `boot_qemu` | Start QEMU with SentientOS. Options: network, smp, force. |
 | `shutdown_qemu` | Send exit to shell and wait for QEMU to exit. |
 | `get_status` | Check if QEMU is running. |
-| `run_program` | Run a userspace program, return output. |
 | `send_command` | Send shell command, return output. |
 | `send_input` | Send raw input, wait for custom marker. |
 | `send_ctrl_c` | Send Ctrl+C, wait for prompt. |


### PR DESCRIPTION
## Summary
- Extract shared helpers (`mcp_err`, `text_result`, `require_running`, `format_command_output`) from MCP server tool handlers to reduce duplication
- Remove redundant `run_program` tool — it was identical to `send_command` since the shell handles both program names and commands the same way
- Inline the `run_on_qemu` helper into `send_command` as the sole remaining caller

## Test plan
- [x] `just clippy` passes with no warnings
- [x] MCP server builds cleanly
- [x] Booted QEMU and verified `send_command` works with both shell commands and program names

🤖 Generated with [Claude Code](https://claude.com/claude-code)