### PR TITLE
ci: Add nightly Cachix upload for devShell closure

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -1,0 +1,27 @@
+name: cachix
+
+on:
+  schedule:
+    - cron: "0 23 * * *"
+  workflow_dispatch:
+
+concurrency: cachix
+
+jobs:
+  push:
+    runs-on: [self-hosted, nix]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          clean: false
+      - uses: cachix/cachix-action@v16
+        with:
+          name: ${{ vars.CACHIX_CACHE_NAME }}
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build and push devShell closure
+        env:
+          CACHE_NAME: ${{ vars.CACHIX_CACHE_NAME }}
+        run: |
+          nix develop --profile /tmp/sentientos-dev-profile -c true
+          cachix push "$CACHE_NAME" /tmp/sentientos-dev-profile
+          rm -f /tmp/sentientos-dev-profile


### PR DESCRIPTION
## Summary
- Adds a scheduled GitHub Actions workflow that pushes the Nix devShell closure to Cachix nightly at 23:00 UTC
- Supports manual dispatch via workflow_dispatch
- Uses concurrency control to prevent overlapping runs
- Cleans up the Nix profile after push to avoid pinning old store paths on the self-hosted runner

## Setup required
- Add secret `CACHIX_AUTH_TOKEN` with a Cachix auth token
- Add variable `CACHIX_CACHE_NAME` with the cache name

## Test plan
- [ ] Verify secrets/variables are configured in GitHub repo settings
- [ ] Trigger manually via Actions tab to confirm the workflow runs successfully
- [ ] Confirm store paths appear in the Cachix dashboard after a push

Generated with [Claude Code](https://claude.com/claude-code)