### PR TITLE
ci: Skip adding cachix as substituter on self-hosted runner

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           name: ${{ vars.CACHIX_CACHE_NAME }}
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          skipAddingSubstituter: true
       - name: Build and push devShell closure
         env:
           CACHE_NAME: ${{ vars.CACHIX_CACHE_NAME }}

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -1,0 +1,27 @@
+name: cachix
+
+on:
+  schedule:
+    - cron: "0 23 * * *"
+  workflow_dispatch:
+
+concurrency: cachix
+
+jobs:
+  push:
+    runs-on: [self-hosted, nix]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          clean: false
+      - uses: cachix/cachix-action@v16
+        with:
+          name: ${{ vars.CACHIX_CACHE_NAME }}
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build and push devShell closure
+        env:
+          CACHE_NAME: ${{ vars.CACHIX_CACHE_NAME }}
+        run: |
+          nix develop --profile /tmp/sentientos-dev-profile -c true
+          cachix push "$CACHE_NAME" /tmp/sentientos-dev-profile
+          rm -f /tmp/sentientos-dev-profile


### PR DESCRIPTION
## Summary
- Adds `skipAddingSubstituter: true` to the cachix-action step
- The self-hosted runner doesn't need cachix as a substituter — we only want to push

## Test plan
- [ ] Re-run the cachix workflow manually and confirm it passes

Generated with [Claude Code](https://claude.com/claude-code)