### PR TITLE
Add pre-commit hook: enforce cargo fmt and just test

### DIFF
--- a/.claude/hooks/commit-reminder.txt
+++ b/.claude/hooks/commit-reminder.txt
@@ -10,8 +10,8 @@ Before stopping, check if you made code changes:
 5. Remove any dead/unused code before committing
 6. After committing, run the commit-review agent (Task tool with subagent_type: commit-review)
 
-NOTE: The pre-commit hook automatically formats staged Rust files and runs `just clippy`.
-A commit will be blocked if clippy reports warnings.
+NOTE: The pre-commit hook automatically formats staged Rust files and runs `just test`.
+A commit will be blocked if tests fail.
 
 DO NOT wait for user to ask you to commit. Commit automatically.
 

--- a/.claude/hooks/commit-reminder.txt
+++ b/.claude/hooks/commit-reminder.txt
@@ -4,12 +4,14 @@ COMMIT CHECK REQUIRED
 Before stopping, check if you made code changes:
 
 1. Run `git status` to see if there are uncommitted changes
-2. Run cargo fmt to format all the code
-3. If changes exist from your work, commit them NOW
-4. Commit incrementally - each small working step, not one big commit
-5. Run `just clippy` before committing to ensure no warnings
-6. Remove any dead/unused code before committing
-7. After committing, run the commit-review agent (Task tool with subagent_type: commit-review)
+2. If changes exist from your work, commit them NOW
+3. Commit incrementally - each small working step, not one big commit
+4. Run `just clippy` before committing to ensure no warnings
+5. Remove any dead/unused code before committing
+6. After committing, run the commit-review agent (Task tool with subagent_type: commit-review)
+
+NOTE: The pre-commit hook automatically formats staged Rust files and runs `just clippy`.
+A commit will be blocked if clippy reports warnings.
 
 DO NOT wait for user to ask you to commit. Commit automatically.
 

--- a/.claude/hooks/commit-reminder.txt
+++ b/.claude/hooks/commit-reminder.txt
@@ -14,10 +14,3 @@ NOTE: The pre-commit hook automatically formats staged Rust files and runs `just
 A commit will be blocked if tests fail.
 
 DO NOT wait for user to ask you to commit. Commit automatically.
-
-IMPORTANT: Do NOT use heredoc syntax (<<EOF) for commit messages.
-Heredocs fail in sandbox mode because they need temp files.
-Use simple quoted strings with embedded newlines instead:
-  git commit -m "First line
-
-  More lines here"

--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,8 @@
 watch_file rust-toolchain
 use flake
+
+# Point git hooks to .githooks/ (pre-commit: fmt + clippy)
+if [ "$(git config --get core.hooksPath 2>/dev/null)" != ".githooks" ]; then
+    git config core.hooksPath .githooks
+    echo "direnv: activated git hooks from .githooks/"
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -8,5 +8,5 @@ if [ -n "$staged_rs_files" ]; then
     echo "$staged_rs_files" | xargs git add
 fi
 
-# Run clippy — commit is blocked on warnings
-just clippy
+# Run tests — commit is blocked if any test fails
+just test

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+# Format only staged Rust files to avoid touching unstaged work
+staged_rs_files=$(git diff --name-only --cached --diff-filter=d -- '*.rs')
+if [ -n "$staged_rs_files" ]; then
+    echo "$staged_rs_files" | xargs rustfmt
+    echo "$staged_rs_files" | xargs git add
+fi
+
+# Run clippy — commit is blocked on warnings
+just clippy


### PR DESCRIPTION
Replaces manual instructions in agent docs with an enforced git hook.
The hook auto-formats code and blocks commits if tests fail.
Activated automatically via direnv (git config core.hooksPath .githooks).