### PR TITLE
Fix UDP: double Ctrl+C, EADDRINUSE, and missing tkill

### DIFF
--- a/kernel/src/processes/fd_table.rs
+++ b/kernel/src/processes/fd_table.rs
@@ -210,6 +210,13 @@ impl FdTable {
             .ok_or(Errno::EBADF)
     }
 
+    pub fn close_all(&mut self) {
+        let table = core::mem::take(&mut self.table);
+        for (_, entry) in table {
+            entry.descriptor.on_close();
+        }
+    }
+
     pub fn close_cloexec_fds(&mut self) {
         let cloexec_fds: Vec<RawFd> = self
             .table

--- a/kernel/src/processes/process.rs
+++ b/kernel/src/processes/process.rs
@@ -251,6 +251,14 @@ impl Process {
         self.threads.remove(&tid);
     }
 
+    pub fn has_no_threads(&self) -> bool {
+        self.threads.is_empty()
+    }
+
+    pub fn close_all_fds(&self) {
+        self.fd_table.lock().close_all();
+    }
+
     pub fn thread_tids(&self) -> Vec<Tid> {
         self.threads.keys().copied().collect()
     }

--- a/kernel/src/processes/process_table.rs
+++ b/kernel/src/processes/process_table.rs
@@ -145,6 +145,16 @@ impl ProcessTable {
         }
     }
 
+    pub fn kill_process_of(&mut self, tid: Tid, exit_status: i32) {
+        let Some(thread) = self.threads.get(&tid).cloned() else {
+            return;
+        };
+        let all_tids = thread.lock().process().lock().thread_tids();
+        for t in all_tids {
+            self.kill(t, exit_status);
+        }
+    }
+
     pub fn kill(&mut self, tid: Tid, exit_status: i32) {
         assert!(
             tid != POWERSAVE_TID,
@@ -181,6 +191,9 @@ impl ProcessTable {
                 let process = t.process();
                 let mut p = process.lock();
                 p.remove_thread(tid);
+                if p.has_no_threads() {
+                    p.close_all_fds();
+                }
                 (p.main_tid(), futex_addr)
             });
 

--- a/kernel/src/processes/scheduler.rs
+++ b/kernel/src/processes/scheduler.rs
@@ -130,10 +130,9 @@ impl CpuScheduler {
 
     pub fn send_ctrl_c(&mut self) {
         process_table::THE.with_lock(|mut pt| {
-            let highest_pid = pt.get_highest_tid_without(&["sosh"]);
-
-            if let Some(pid) = highest_pid {
-                pt.kill(pid, 0);
+            let highest_tid = pt.get_highest_tid_without(&["sosh"]);
+            if let Some(tid) = highest_tid {
+                pt.kill_process_of(tid, 0);
             }
         });
         self.schedule();

--- a/kernel/src/syscalls/linux.rs
+++ b/kernel/src/syscalls/linux.rs
@@ -79,6 +79,7 @@ linux_syscalls! {
     SYSCALL_NR_SET_TID_ADDRESS => set_tid_address(tidptr: *mut c_int);
     SYSCALL_NR_SIGALTSTACK => sigaltstack(uss: Option<*const stack_t>, uoss: Option<*mut stack_t>);
     SYSCALL_NR_SOCKET => socket(domain: c_int, typ: c_int, protocol: c_int);
+    SYSCALL_NR_TKILL => tkill(tid: c_int, sig: c_int);
     SYSCALL_NR_WAIT4 => wait4(pid: c_int, status: Option<*mut c_int>, options: c_int, rusage: usize);
     SYSCALL_NR_WRITEV => writev(fd: c_int, iov: *const iovec, iovcnt: c_int);
     SYSCALL_NR_WRITE => write(fd: c_int, buf: *const u8, count: usize);
@@ -599,6 +600,15 @@ impl LinuxSyscalls for LinuxSyscallHandler {
 
     async fn gettid(&mut self) -> Result<isize, headers::errno::Errno> {
         Ok(self.current_tid.as_isize())
+    }
+
+    async fn tkill(&mut self, tid: c_int, sig: c_int) -> Result<isize, Errno> {
+        if sig == 0 {
+            return Ok(0);
+        }
+        let target_tid = Tid::try_from_i32(tid).ok_or(Errno::ESRCH)?;
+        process_table::THE.lock().kill(target_tid, sig);
+        Ok(0)
     }
 
     async fn socket(

--- a/system-tests/src/tests/signals.rs
+++ b/system-tests/src/tests/signals.rs
@@ -20,6 +20,27 @@ async fn should_exit_program() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn should_rerun_udp_after_ctrl_c() -> anyhow::Result<()> {
+    let mut solaya =
+        QemuInstance::start_with(QemuOptions::default().add_network_card(true)).await?;
+
+    solaya
+        .run_prog_waiting_for("udp", "Listening on 1234")
+        .await?;
+    solaya.ctrl_c_and_assert_prompt().await?;
+
+    solaya
+        .run_prog_waiting_for("udp", "Listening on 1234")
+        .await?;
+    solaya.ctrl_c_and_assert_prompt().await?;
+
+    let output = solaya.run_prog("prog1").await?;
+    assert_eq!(output, "Hello from Prog1\n");
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn should_not_exit_sosh() -> anyhow::Result<()> {
     let mut solaya = QemuInstance::start().await?;
 


### PR DESCRIPTION
## Summary
- **Ctrl+C now kills entire process**: `send_ctrl_c()` uses new `kill_process_of()` to kill all threads of the target process, not just the highest TID. Fixes the double Ctrl+C issue with multi-threaded programs like `udp`.
- **FDs closed on process death**: When the last thread of a process dies, `close_all_fds()` runs, dropping `SharedAssignedSocket` Arcs and freeing UDP ports via `AssignedSocket::drop()`. Fixes EADDRINUSE on re-run.
- **`tkill` syscall implemented**: Prevents kernel panic when musl's abort handler calls `tkill(gettid(), SIGABRT)`.

## Test plan
- [x] `just clippy` passes with no warnings
- [x] All 26 system tests pass, including:
  - `signals::should_exit_program` — single Ctrl+C exits UDP
  - `signals::should_rerun_udp_after_ctrl_c` — **new test**: runs UDP twice with Ctrl+C in between, verifying port reuse
  - `net::udp` — UDP send/receive still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)