### PR TITLE
feat: implement process group IDs and session IDs

### DIFF
--- a/doc/ai/PROCESSES.md
+++ b/doc/ai/PROCESSES.md
@@ -21,6 +21,8 @@ pub struct Process {
     fd_table: FdTable,                         // File descriptor table (stdin/stdout/stderr + sockets)
     threads: BTreeMap<Tid, ThreadWeakRef>,
     main_tid: Tid,
+    pgid: Tid,                                 // Process group ID
+    sid: Tid,                                  // Session ID
     brk: Brk,                                  // Heap break manager
 }
 ```
@@ -212,6 +214,29 @@ When a process dies in `ProcessTable::kill()`, orphans (children of the dying pr
 ### getppid syscall
 
 Linux syscall 173 (`getppid`) returns `thread.parent_tid()` (read from Thread, not Process).
+
+## Process Groups and Sessions
+
+Each process has a **process group ID** (`pgid`) and **session ID** (`sid`), stored on `Process`.
+
+### Initialization
+- **Init process** (`Thread::from_elf`): `pgid = tid, sid = tid` (session and group leader)
+- **Powersave thread**: `pgid = 0, sid = 0`
+- **vfork child** (`clone_vfork`): inherits parent's `pgid` and `sid`
+- **execve**: preserves the old process's `pgid` and `sid`
+
+### Syscalls
+- `getpgid(pid)` — returns PGID of `pid` (0 = self)
+- `getsid(pid)` — returns SID of `pid` (0 = self)
+- `setpgid(pid, pgid)` — set PGID; can only set own or child's. `pid=0` means self, `pgid=0` means use `pid`
+- `setsid()` — create new session (sets `pgid = pid, sid = pid`). Fails with `EPERM` if already a group leader
+
+### wait4 with process groups
+`wait4` supports all Linux `pid` modes:
+- `pid > 0` — wait for specific child
+- `pid == -1` — wait for any child
+- `pid == 0` — wait for any child in caller's process group
+- `pid < -1` — wait for any child in process group `abs(pid)`
 
 ## ELF Loader
 

--- a/kernel/src/processes/process.rs
+++ b/kernel/src/processes/process.rs
@@ -33,6 +33,8 @@ pub struct Process {
     fd_table: Arc<Spinlock<FdTable>>,
     threads: BTreeMap<Tid, ThreadWeakRef>,
     main_tid: Tid,
+    pgid: Tid,
+    sid: Tid,
     brk: Brk,
     vfork_parent: Option<ProcessRef>,
 }
@@ -60,6 +62,8 @@ impl Process {
         allocated_pages: Vec<PinnedHeapPages>,
         brk: Brk,
         main_thread: Tid,
+        pgid: Tid,
+        sid: Tid,
     ) -> Self {
         Self {
             name,
@@ -71,6 +75,8 @@ impl Process {
             threads: BTreeMap::new(),
             brk,
             main_tid: main_thread,
+            pgid,
+            sid,
             vfork_parent: None,
         }
     }
@@ -220,6 +226,22 @@ impl Process {
 
     pub fn main_tid(&self) -> Tid {
         self.main_tid
+    }
+
+    pub fn pgid(&self) -> Tid {
+        self.pgid
+    }
+
+    pub fn sid(&self) -> Tid {
+        self.sid
+    }
+
+    pub fn set_pgid(&mut self, pgid: Tid) {
+        self.pgid = pgid;
+    }
+
+    pub fn set_sid(&mut self, sid: Tid) {
+        self.sid = sid;
     }
 
     pub fn fd_table(&self) -> crate::klibc::SpinlockGuard<'_, FdTable> {

--- a/kernel/src/processes/process_table.rs
+++ b/kernel/src/processes/process_table.rs
@@ -16,7 +16,10 @@ use crate::{
     processes::{futex, process::POWERSAVE_TID, thread::Thread},
 };
 
-use super::thread::{ThreadRef, ThreadState};
+use super::{
+    thread::{ThreadRef, ThreadState},
+    wait_child::WaitPid,
+};
 
 pub static RUN_QUEUE: Spinlock<VecDeque<ThreadRef>> = Spinlock::new(VecDeque::new());
 static LIVE_THREAD_COUNT: AtomicUsize = AtomicUsize::new(0);
@@ -91,28 +94,36 @@ impl ProcessTable {
         }
     }
 
-    pub fn take_zombie(&mut self, parent_tid: Tid, pid: i32) -> Option<(Tid, i32)> {
+    pub fn take_zombie(&mut self, parent_tid: Tid, target: &WaitPid) -> Option<(Tid, i32)> {
         let children = self.children.get(&parent_tid)?;
 
-        let tid = if pid > 0 {
-            let tid = Tid::try_from_i32(pid).expect("pid is positive");
-            if !children.contains(&tid) {
-                return None;
+        let tid = match target {
+            WaitPid::Specific(wanted) => {
+                if !children.contains(wanted) {
+                    return None;
+                }
+                let is_zombie = self
+                    .threads
+                    .get(wanted)?
+                    .with_lock(|t| matches!(t.get_state(), ThreadState::Zombie(_)));
+                if !is_zombie {
+                    return None;
+                }
+                *wanted
             }
-            let is_zombie = self
-                .threads
-                .get(&tid)?
-                .with_lock(|t| matches!(t.get_state(), ThreadState::Zombie(_)));
-            if !is_zombie {
-                return None;
-            }
-            tid
-        } else {
-            *children.iter().find(|&&child_tid| {
+            WaitPid::Any => *children.iter().find(|&&child_tid| {
                 self.threads.get(&child_tid).is_some_and(|t| {
                     t.with_lock(|t| matches!(t.get_state(), ThreadState::Zombie(_)))
                 })
-            })?
+            })?,
+            WaitPid::Pgid(pgid) => *children.iter().find(|&&child_tid| {
+                self.threads.get(&child_tid).is_some_and(|t| {
+                    t.with_lock(|t| {
+                        matches!(t.get_state(), ThreadState::Zombie(_))
+                            && t.process().lock().pgid() == *pgid
+                    })
+                })
+            })?,
         };
 
         let thread = self.threads.remove(&tid).expect("tid was just found");
@@ -127,6 +138,31 @@ impl ProcessTable {
         self.children.remove(&tid);
 
         Some((tid, i32::from(exit_code) << 8))
+    }
+
+    pub fn get_pgid_of(&self, tid: Tid) -> Option<Tid> {
+        let thread = self.threads.get(&tid)?;
+        Some(thread.with_lock(|t| t.process().lock().pgid()))
+    }
+
+    pub fn get_sid_of(&self, tid: Tid) -> Option<Tid> {
+        let thread = self.threads.get(&tid)?;
+        Some(thread.with_lock(|t| t.process().lock().sid()))
+    }
+
+    pub fn set_pgid_of(&mut self, tid: Tid, pgid: Tid) -> bool {
+        if let Some(thread) = self.threads.get(&tid) {
+            thread.with_lock(|t| t.process().lock().set_pgid(pgid));
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn is_child_of(&self, parent_tid: Tid, child_tid: Tid) -> bool {
+        self.children
+            .get(&parent_tid)
+            .is_some_and(|c| c.contains(&child_tid))
     }
 
     pub fn has_any_child_of(&self, parent_tid: Tid) -> bool {

--- a/kernel/src/processes/thread.rs
+++ b/kernel/src/processes/thread.rs
@@ -191,6 +191,8 @@ impl Thread {
             true,
             Brk::empty(),
             POWERSAVE_TID,
+            POWERSAVE_TID,
+            POWERSAVE_TID,
         )
     }
 
@@ -214,9 +216,10 @@ impl Thread {
         register_state[Register::a0] = args_start.as_usize();
         register_state[Register::sp] = args_start.as_usize();
 
+        let tid = get_next_tid();
         Ok(Self::new_process(
             name,
-            get_next_tid(),
+            tid,
             register_state,
             page_table,
             entry_address,
@@ -224,6 +227,8 @@ impl Thread {
             false,
             brk,
             parent_tid,
+            tid,
+            tid,
         ))
     }
 
@@ -238,6 +243,8 @@ impl Thread {
         in_kernel_mode: bool,
         brk: Brk,
         parent_tid: Tid,
+        pgid: Tid,
+        sid: Tid,
     ) -> ThreadRef {
         let name = Arc::new(name.into());
         let process = Arc::new(Spinlock::new(Process::new(
@@ -246,6 +253,8 @@ impl Thread {
             allocated_pages,
             brk,
             tid,
+            pgid,
+            sid,
         )));
 
         let main_thread = Thread::new(

--- a/kernel/src/processes/wait_child.rs
+++ b/kernel/src/processes/wait_child.rs
@@ -8,17 +8,23 @@ use headers::errno::Errno;
 
 use super::process_table;
 
+pub enum WaitPid {
+    Specific(Tid),
+    Any,
+    Pgid(Tid),
+}
+
 pub struct WaitChild {
     parent_main_tid: Tid,
-    pid: i32,
+    target: WaitPid,
     wnohang: bool,
 }
 
 impl WaitChild {
-    pub fn new(parent_main_tid: Tid, pid: i32, wnohang: bool) -> Self {
+    pub fn new(parent_main_tid: Tid, target: WaitPid, wnohang: bool) -> Self {
         Self {
             parent_main_tid,
-            pid,
+            target,
             wnohang,
         }
     }
@@ -29,7 +35,7 @@ impl Future for WaitChild {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         process_table::THE.with_lock(|mut pt| {
-            if let Some((tid, status)) = pt.take_zombie(self.parent_main_tid, self.pid) {
+            if let Some((tid, status)) = pt.take_zombie(self.parent_main_tid, &self.target) {
                 return Poll::Ready(Ok((tid, status)));
             }
 

--- a/kernel/src/syscalls/linux.rs
+++ b/kernel/src/syscalls/linux.rs
@@ -21,7 +21,7 @@ use crate::{
         thread::{Thread, ThreadRef, VforkState, VforkWait, get_next_tid},
         timer,
         userspace_ptr::UserspacePtr,
-        wait_child::WaitChild,
+        wait_child::{WaitChild, WaitPid},
     },
     syscalls::macros::linux_syscalls,
 };
@@ -57,8 +57,10 @@ linux_syscalls! {
     SYSCALL_NR_EXIT_GROUP => exit_group(status: c_int);
     SYSCALL_NR_FCNTL => fcntl(fd: c_int, cmd: c_int, arg: c_ulong);
     SYSCALL_NR_FUTEX => futex(uaddr: usize, op: c_int, val: c_uint, timeout: usize, uaddr2: usize, val3: c_uint);
+    SYSCALL_NR_GETPGID => getpgid(pid: c_int);
     SYSCALL_NR_GETPID => getpid();
     SYSCALL_NR_GETPPID => getppid();
+    SYSCALL_NR_GETSID => getsid(pid: c_int);
     SYSCALL_NR_GETTID => gettid();
     SYSCALL_NR_IOCTL => ioctl(fd: c_int, op: c_uint, arg: usize);
     SYSCALL_NR_MADVISE => madvise(addr: usize, length: usize, advice: c_int);
@@ -75,6 +77,8 @@ linux_syscalls! {
     SYSCALL_NR_RT_SIGACTION => rt_sigaction(sig: c_uint, act: Option<*const sigaction>, oact: Option<*mut sigaction>, sigsetsize: usize);
     SYSCALL_NR_RT_SIGPROCMASK => rt_sigprocmask(how: c_uint, set: Option<*const sigset_t>, oldset: Option<*mut sigset_t>, sigsetsize: usize);
     SYSCALL_NR_SENDTO => sendto(fd: c_int, buf: *const u8, len: usize, flags: c_int, dest_addr: *const u8, addrlen: c_uint);
+    SYSCALL_NR_SETPGID => setpgid(pid: c_int, pgid: c_int);
+    SYSCALL_NR_SETSID => setsid();
     SYSCALL_NR_SET_ROBUST_LIST => set_robust_list(head: usize, len: usize);
     SYSCALL_NR_SET_TID_ADDRESS => set_tid_address(tidptr: *mut c_int);
     SYSCALL_NR_SIGALTSTACK => sigaltstack(uss: Option<*const stack_t>, uoss: Option<*mut stack_t>);
@@ -602,6 +606,72 @@ impl LinuxSyscalls for LinuxSyscallHandler {
         Ok(self.current_tid.as_isize())
     }
 
+    async fn getpgid(&mut self, pid: c_int) -> Result<isize, Errno> {
+        if pid == 0 {
+            let pgid = self.current_process.with_lock(|p| p.pgid());
+            return Ok(pgid.as_isize());
+        }
+        let target = Tid::try_from_i32(pid).ok_or(Errno::ESRCH)?;
+        let pgid = process_table::THE
+            .lock()
+            .get_pgid_of(target)
+            .ok_or(Errno::ESRCH)?;
+        Ok(pgid.as_isize())
+    }
+
+    async fn getsid(&mut self, pid: c_int) -> Result<isize, Errno> {
+        if pid == 0 {
+            let sid = self.current_process.with_lock(|p| p.sid());
+            return Ok(sid.as_isize());
+        }
+        let target = Tid::try_from_i32(pid).ok_or(Errno::ESRCH)?;
+        let sid = process_table::THE
+            .lock()
+            .get_sid_of(target)
+            .ok_or(Errno::ESRCH)?;
+        Ok(sid.as_isize())
+    }
+
+    async fn setpgid(&mut self, pid: c_int, pgid: c_int) -> Result<isize, Errno> {
+        let my_main_tid = self.current_process.with_lock(|p| p.main_tid());
+        let target_tid = if pid == 0 {
+            my_main_tid
+        } else {
+            Tid::try_from_i32(pid).ok_or(Errno::EINVAL)?
+        };
+        let new_pgid = if pgid == 0 {
+            target_tid
+        } else {
+            Tid::try_from_i32(pgid).ok_or(Errno::EINVAL)?
+        };
+
+        if target_tid != my_main_tid {
+            let is_child = process_table::THE
+                .lock()
+                .is_child_of(my_main_tid, target_tid);
+            if !is_child {
+                return Err(Errno::ESRCH);
+            }
+        }
+
+        if !process_table::THE.lock().set_pgid_of(target_tid, new_pgid) {
+            return Err(Errno::ESRCH);
+        }
+        Ok(0)
+    }
+
+    async fn setsid(&mut self) -> Result<isize, Errno> {
+        self.current_process.with_lock(|mut p| {
+            let main_tid = p.main_tid();
+            if p.pgid() == main_tid {
+                return Err(Errno::EPERM);
+            }
+            p.set_pgid(main_tid);
+            p.set_sid(main_tid);
+            Ok(main_tid.as_isize())
+        })
+    }
+
     async fn tkill(&mut self, tid: c_int, sig: c_int) -> Result<isize, Errno> {
         if sig == 0 {
             return Ok(0);
@@ -770,10 +840,6 @@ impl LinuxSyscalls for LinuxSyscallHandler {
         options: c_int,
         _rusage: usize,
     ) -> Result<isize, headers::errno::Errno> {
-        assert!(
-            pid > 0 || pid == -1,
-            "wait4: unsupported pid value {pid} (no process groups yet)"
-        );
         let wnohang = (options & headers::syscall_types::WNOHANG as c_int) != 0;
         assert!(
             options & !(headers::syscall_types::WNOHANG as c_int) == 0,
@@ -781,7 +847,19 @@ impl LinuxSyscalls for LinuxSyscallHandler {
         );
 
         let parent_main_tid = self.current_thread.lock().get_tid();
-        let (child_tid, wait_status) = WaitChild::new(parent_main_tid, pid, wnohang).await?;
+        let target = if pid > 0 {
+            WaitPid::Specific(Tid::try_from_i32(pid).expect("pid is positive"))
+        } else if pid == -1 {
+            WaitPid::Any
+        } else if pid == 0 {
+            let own_pgid = self.current_process.with_lock(|p| p.pgid());
+            WaitPid::Pgid(own_pgid)
+        } else {
+            // pid < -1: wait for any child whose pgid == abs(pid)
+            let abs_pid = pid.checked_neg().ok_or(Errno::EINVAL)?;
+            WaitPid::Pgid(Tid::try_from_i32(abs_pid).expect("abs(pid) is positive"))
+        };
+        let (child_tid, wait_status) = WaitChild::new(parent_main_tid, target, wnohang).await?;
 
         status.write_if_not_none(wait_status)?;
 
@@ -854,12 +932,16 @@ impl LinuxSyscalls for LinuxSyscallHandler {
         let loaded = loader::load_elf(&elf, name, &args).expect("ELF loading must succeed");
 
         let process_name = Arc::new(String::from(name));
+        let old_process = self.get_process();
+        let (old_pgid, old_sid) = old_process.with_lock(|p| (p.pgid(), p.sid()));
         let new_process = Arc::new(crate::klibc::Spinlock::new(Process::new(
             process_name.clone(),
             loaded.page_tables,
             loaded.allocated_pages,
             loaded.brk,
             self.current_thread.lock().get_tid(),
+            old_pgid,
+            old_sid,
         )));
 
         let mut inherited_fd_table = self.get_process().with_lock(|p| p.fd_table().clone());
@@ -917,8 +999,15 @@ impl LinuxSyscallHandler {
         let parent_pc = arch::cpu::read_sepc();
 
         let parent_process = self.current_process.clone();
-        let (parent_main_tid, child_name) =
-            parent_process.with_lock(|p| (p.main_tid(), Arc::new(String::from(p.get_name()))));
+        let (parent_main_tid, child_name, parent_pgid, parent_sid) =
+            parent_process.with_lock(|p| {
+                (
+                    p.main_tid(),
+                    Arc::new(String::from(p.get_name())),
+                    p.pgid(),
+                    p.sid(),
+                )
+            });
 
         let vfork_state = VforkState::new();
         let child_tid = get_next_tid();
@@ -931,6 +1020,8 @@ impl LinuxSyscallHandler {
             Vec::new(),
             Brk::empty(),
             child_tid,
+            parent_pgid,
+            parent_sid,
         )));
         child_process
             .lock()

--- a/system-tests/src/tests/process_relation.rs
+++ b/system-tests/src/tests/process_relation.rs
@@ -10,3 +10,46 @@ async fn getppid_returns_valid_parent() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn pgid_and_sid_syscalls() -> anyhow::Result<()> {
+    let mut solaya = QemuInstance::start().await?;
+
+    let output = solaya.run_prog("pgid-test").await?;
+    assert!(
+        output.contains("OK"),
+        "pgid-test should print OK, got: {output}"
+    );
+    assert!(output.contains("pgid="), "should print pgid");
+    assert!(output.contains("sid="), "should print sid");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn setpgid_creates_new_process_group() -> anyhow::Result<()> {
+    let mut solaya = QemuInstance::start().await?;
+
+    let output = solaya.run_prog("pgid-child setpgid").await?;
+    assert!(
+        output.contains("OK"),
+        "pgid-child setpgid should print OK, got: {output}"
+    );
+    assert!(output.contains("child_pgid="), "should print child_pgid");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn setsid_creates_new_session() -> anyhow::Result<()> {
+    let mut solaya = QemuInstance::start().await?;
+
+    let output = solaya.run_prog("pgid-child setsid").await?;
+    assert!(
+        output.contains("OK"),
+        "pgid-child setsid should print OK, got: {output}"
+    );
+    assert!(output.contains("child_sid="), "should print child_sid");
+
+    Ok(())
+}

--- a/todo/overview.md
+++ b/todo/overview.md
@@ -4,65 +4,22 @@ This document contains research summaries for planned future enhancements. Each 
 
 ## Table of Contents
 
-1. [Proper Process IDs and Groups](#1-proper-process-ids-and-groups)
-2. [Linux-like Signals](#2-linux-like-signals)
-3. [Virtual File System (VFS)](#3-virtual-file-system-vfs)
-4. [QEMU Block Device Driver](#4-qemu-block-device-driver)
-5. [ext2 Filesystem](#5-ext2-filesystem)
-6. [Feasible Coreutils](#6-feasible-coreutils)
-7. [QEMU Framebuffer](#7-qemu-framebuffer)
-8. [Port Doom](#8-port-doom)
-9. [Async Network Reception with Interrupts](#9-async-network-reception-with-interrupts)
-10. [DHCP Client](#10-dhcp-client)
-11. [Minimal TCP Implementation](#11-minimal-tcp-implementation)
-12. [Dynamic Linking](#12-dynamic-linking)
-13. [QEMU Random Device Driver](#13-qemu-random-device-driver)
+1. [Linux-like Signals](#1-linux-like-signals)
+2. [Virtual File System (VFS)](#2-virtual-file-system-vfs)
+3. [QEMU Block Device Driver](#3-qemu-block-device-driver)
+4. [ext2 Filesystem](#4-ext2-filesystem)
+5. [Feasible Coreutils](#5-feasible-coreutils)
+6. [QEMU Framebuffer](#6-qemu-framebuffer)
+7. [Port Doom](#7-port-doom)
+8. [Async Network Reception with Interrupts](#8-async-network-reception-with-interrupts)
+9. [DHCP Client](#9-dhcp-client)
+10. [Minimal TCP Implementation](#10-minimal-tcp-implementation)
+11. [Dynamic Linking](#11-dynamic-linking)
+12. [QEMU Random Device Driver](#12-qemu-random-device-driver)
 
 ---
 
-## 1. Proper Process IDs and Groups
-
-**Complexity:** Medium
-
-### Currently Implemented ✅
-- Thread ID (TID): Unique per thread
-- Process ID (PID): Returns main thread's TID (partial implementation)
-- Parent Process ID (PPID): Tracked via `parent_tid`
-
-### Missing ❌
-- **Thread Group ID (TGID)**: Not tracked separately (conflated with PID)
-- **Process Group ID (PGID)**: Not tracked at all
-- **Session ID (SID)**: Not tracked at all
-
-### Required Changes
-
-**Data Structures:**
-Add to `Process` or `Thread`:
-```rust
-pgid: Tid  // Process group ID
-sid: Tid   // Session ID
-```
-
-**Syscall Implementations:**
-- `getpgid(pid)` - Get PGID (syscall #155)
-- `setpgid(pid, pgid)` - Set PGID (syscall #154)
-- `getsid(pid)` - Get SID (syscall #156)
-- `setsid()` - Create new session (syscall #157)
-
-**Initialization:**
-- Init process: `pgid=1`, `sid=1`
-- Fork/clone: Child inherits parent's PGID and SID
-- Constraints: `setsid()` fails if caller is process group leader
-
-### Purpose
-- PGID: Job control (shell pipelines, process groups)
-- SID: Session management (terminal control)
-
-**Estimated effort:** 1-2 weeks
-
----
-
-## 2. Linux-like Signals
+## 1. Linux-like Signals
 
 **Complexity:** Medium
 
@@ -113,7 +70,7 @@ sid: Tid   // Session ID
 
 ---
 
-## 3. Virtual File System (VFS)
+## 2. Virtual File System (VFS)
 
 **Complexity:** Medium to High
 
@@ -188,7 +145,7 @@ pub enum FileDescriptor {
 
 ---
 
-## 4. QEMU Block Device Driver
+## 3. QEMU Block Device Driver
 
 **Complexity:** Medium
 
@@ -233,7 +190,7 @@ struct virtio_blk_req {
 
 ---
 
-## 5. ext2 Filesystem
+## 4. ext2 Filesystem
 
 **Complexity:** Medium to High
 
@@ -268,8 +225,8 @@ struct virtio_blk_req {
 - Similar traversal + update bitmaps + allocate blocks
 
 ### Integration
-- Requires VFS layer (see #3)
-- Requires block device driver (see #4)
+- Requires VFS layer (see #2)
+- Requires block device driver (see #3)
 
 ### Complexity Assessment
 
@@ -291,13 +248,13 @@ struct virtio_blk_req {
 
 ---
 
-## 6. Feasible Coreutils
+## 5. Feasible Coreutils
 
 **Complexity:** Varies (Low to High per utility)
 
 ### Prerequisites
-- VFS implementation (#3)
-- Block device (#4) or tmpfs
+- VFS implementation (#2)
+- Block device (#3) or tmpfs
 - Core filesystem syscalls
 
 ### Required Syscalls
@@ -370,7 +327,7 @@ find, sort, diff, ln, readlink, dd
 
 ---
 
-## 7. QEMU Framebuffer
+## 6. QEMU Framebuffer
 
 **Complexity:** Medium
 
@@ -425,7 +382,7 @@ Start with **bochs-display** - reuses PCI infrastructure, simpler than virtio-gp
 
 ---
 
-## 8. Port Doom
+## 7. Port Doom
 
 **Complexity:** High (several weeks)
 
@@ -449,16 +406,16 @@ No sound support.
 - `read/write`, `mmap/munmap`, `brk`, `nanosleep`
 
 ❌ Missing:
-- **Framebuffer access** - Need graphics device (#7)
-- **File system** - Need `open/openat/close` for reading WAD files (#3)
+- **Framebuffer access** - Need graphics device (#6)
+- **File system** - Need `open/openat/close` for reading WAD files (#2)
 - **Keyboard input** - Need input event interface
 - **Timing** - Need `clock_gettime` for `DG_GetTicksMs`
 
 ### What Needs Implementation
 
 **Major Components:**
-1. **Framebuffer** (#7) - VirtIO-GPU or bochs-display driver
-2. **File System** (#3) - Basic VFS for reading WAD file
+1. **Framebuffer** (#6) - VirtIO-GPU or bochs-display driver
+2. **File System** (#2) - Basic VFS for reading WAD file
    - Alternative: Embed doom1.wad (shareware, ~4MB) in kernel initially
 3. **Keyboard Driver** - VirtIO input or PS/2 keyboard
 4. **Timing** - `clock_gettime` syscall
@@ -477,13 +434,13 @@ qemu-system-riscv64 \
 - All pieces must work together
 - Debugging rendering issues
 
-**Dependencies:** Items #3 (VFS), #7 (framebuffer), plus keyboard driver
+**Dependencies:** Items #2 (VFS), #6 (framebuffer), plus keyboard driver
 
 **Estimated effort:** 2-4 weeks once dependencies are complete
 
 ---
 
-## 9. Async Network Reception with Interrupts
+## 8. Async Network Reception with Interrupts
 
 **Complexity:** Low to Medium
 
@@ -544,7 +501,7 @@ impl Future for RecvWait {
 
 ---
 
-## 10. DHCP Client
+## 9. DHCP Client
 
 **Complexity:** Low to Medium
 
@@ -616,7 +573,7 @@ async fn sys_solaya_set_ip(addr_u32: u32) -> Result<isize, Errno> {
 
 ---
 
-## 11. Minimal TCP Implementation
+## 10. Minimal TCP Implementation
 
 **Complexity:** Medium to High
 
@@ -687,7 +644,7 @@ Four-way handshake (FIN, ACK, FIN, ACK) - can optimize to three-way.
 
 ---
 
-## 12. Dynamic Linking
+## 11. Dynamic Linking
 
 **Complexity:** Medium to High
 
@@ -735,7 +692,7 @@ Four-way handshake (FIN, ACK, FIN, ACK) - can optimize to three-way.
 
 ✅ Already implemented: `mmap`, `munmap`, `mprotect`, `brk`
 
-❌ Missing: **Filesystem syscalls** (#3)
+❌ Missing: **Filesystem syscalls** (#2)
 - `openat`, `close`, `read`, `fstat` - To open and read shared libraries
 
 ### Complexity Assessment
@@ -764,13 +721,13 @@ Four-way handshake (FIN, ACK, FIN, ACK) - can optimize to three-way.
 - TLS support
 - Performance optimizations
 
-**Main Blocker:** Filesystem support (#3) - currently embeds all binaries
+**Main Blocker:** Filesystem support (#2) - currently embeds all binaries
 
 **Estimated effort:** 2-4 weeks once filesystem exists
 
 ---
 
-## 13. QEMU Random Device Driver
+## 12. QEMU Random Device Driver
 
 **Complexity:** Low to Medium
 
@@ -851,25 +808,24 @@ pub fn is_virtio_rng(device: &PCIDevice) -> bool {
 ## Dependencies and Recommended Order
 
 ### Phase 1: Foundation (Critical Infrastructure)
-1. **#1 - Process IDs/Groups** (Foundation for job control)
-2. **#9 - Async Network with Interrupts** (Better performance)
-3. **#13 - QEMU Random Device** (Security foundation)
+1. **#8 - Async Network with Interrupts** (Better performance)
+2. **#12 - QEMU Random Device** (Security foundation)
 
 ### Phase 2: Storage and Filesystems
-4. **#4 - QEMU Block Device Driver** (Prerequisite for filesystems)
-5. **#3 - Virtual File System** (Core abstraction)
-6. **#5 - ext2 Filesystem** (Persistent storage)
-7. **#6 - Coreutils** (User-facing utilities)
+3. **#3 - QEMU Block Device Driver** (Prerequisite for filesystems)
+4. **#2 - Virtual File System** (Core abstraction)
+5. **#4 - ext2 Filesystem** (Persistent storage)
+6. **#5 - Coreutils** (User-facing utilities)
 
 ### Phase 3: Networking Enhancements
-8. **#10 - DHCP Client** (Network configuration)
-9. **#11 - Minimal TCP** (Protocol expansion)
+7. **#9 - DHCP Client** (Network configuration)
+8. **#10 - Minimal TCP** (Protocol expansion)
 
 ### Phase 4: Advanced Features
-10. **#2 - Linux Signals** (Process control)
-11. **#12 - Dynamic Linking** (Shared libraries)
-12. **#7 - Framebuffer** (Graphics foundation)
-13. **#8 - Port Doom** (Showcase project)
+9. **#1 - Linux Signals** (Process control)
+10. **#11 - Dynamic Linking** (Shared libraries)
+11. **#6 - Framebuffer** (Graphics foundation)
+12. **#7 - Port Doom** (Showcase project)
 
 ---
 
@@ -877,13 +833,13 @@ pub fn is_virtio_rng(device: &PCIDevice) -> bool {
 
 Before implementation, consider:
 
-1. **Storage Strategy:** For items #4-7 (VFS/filesystem), do you want to start with tmpfs (in-memory) or go directly to block device + ext2?
+1. **Storage Strategy:** For items #2-5 (VFS/filesystem), do you want to start with tmpfs (in-memory) or go directly to block device + ext2?
 
-2. **Framebuffer Choice (#7):** ramfb (simplest), bochs-display (recommended), or virtio-gpu (most complex)?
+2. **Framebuffer Choice (#6):** ramfb (simplest), bochs-display (recommended), or virtio-gpu (most complex)?
 
-3. **Dynamic Linking (#12):** Should we prioritize this over other features, or wait until filesystem support is solid?
+3. **Dynamic Linking (#11):** Should we prioritize this over other features, or wait until filesystem support is solid?
 
-4. **Signals (#2):** Do you want full signal support including SIGCHLD/job control, or minimal signal delivery first?
+4. **Signals (#1):** Do you want full signal support including SIGCHLD/job control, or minimal signal delivery first?
 
 5. **Testing Strategy:** Should each major feature include new system tests, or batch testing?
 

--- a/userspace/src/bin/pgid-child.rs
+++ b/userspace/src/bin/pgid-child.rs
@@ -1,0 +1,32 @@
+extern crate userspace;
+
+unsafe extern "C" {
+    fn getpgid(pid: i32) -> i32;
+    fn getsid(pid: i32) -> i32;
+    fn setpgid(pid: i32, pgid: i32) -> i32;
+    fn setsid() -> i32;
+    fn getpid() -> i32;
+}
+
+fn main() {
+    let pid = unsafe { getpid() };
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.len() > 1 && args[1] == "setpgid" {
+        let ret = unsafe { setpgid(0, 0) };
+        assert_eq!(ret, 0, "setpgid(0,0) should succeed");
+        let new_pgid = unsafe { getpgid(0) };
+        assert_eq!(new_pgid, pid, "after setpgid(0,0), pgid should equal pid");
+        println!("child_pgid={new_pgid}");
+    } else if args.len() > 1 && args[1] == "setsid" {
+        let ret = unsafe { setsid() };
+        assert_eq!(ret, pid, "setsid should return new sid == pid");
+        let new_sid = unsafe { getsid(0) };
+        assert_eq!(new_sid, pid, "after setsid, sid should equal pid");
+        let new_pgid = unsafe { getpgid(0) };
+        assert_eq!(new_pgid, pid, "after setsid, pgid should equal pid");
+        println!("child_sid={new_sid}");
+    }
+
+    println!("OK");
+}

--- a/userspace/src/bin/pgid-test.rs
+++ b/userspace/src/bin/pgid-test.rs
@@ -1,0 +1,30 @@
+extern crate userspace;
+
+unsafe extern "C" {
+    fn getpgid(pid: i32) -> i32;
+    fn getsid(pid: i32) -> i32;
+    fn getpid() -> i32;
+}
+
+fn main() {
+    let pid = unsafe { getpid() };
+
+    let pgid = unsafe { getpgid(0) };
+    println!("pgid={pgid}");
+    assert!(pgid > 0, "pgid should be positive");
+
+    let sid = unsafe { getsid(0) };
+    println!("sid={sid}");
+    assert!(sid > 0, "sid should be positive");
+
+    // getpgid/getsid with explicit pid should match
+    let pgid2 = unsafe { getpgid(pid) };
+    assert_eq!(pgid2, pgid, "getpgid(pid) should match getpgid(0)");
+    let sid2 = unsafe { getsid(pid) };
+    assert_eq!(sid2, sid, "getsid(pid) should match getsid(0)");
+
+    // pgid and sid should be inherited from the chain (same value)
+    assert_eq!(pgid, sid, "pgid and sid should match (inherited from init)");
+
+    println!("OK");
+}


### PR DESCRIPTION
## Summary
- Add `pgid` and `sid` fields to `Process` struct, threaded through all creation paths (init, powersave, vfork, execve)
- Implement 4 new syscalls: `getpgid`, `getsid`, `setpgid`, `setsid`
- Extend `wait4` to support all Linux pid modes: specific pid, any child, same process group (`pid==0`), and arbitrary process group (`pid<-1`)
- Add `pgid-test` and `pgid-child` userspace test programs with system tests

## Test plan
- [x] `just clippy` passes with no warnings
- [x] All 138 unit tests pass
- [x] All 29 system tests pass, including 3 new tests:
  - `pgid_and_sid_syscalls` — validates getpgid/getsid return correct values
  - `setpgid_creates_new_process_group` — validates setpgid(0,0) creates new group
  - `setsid_creates_new_session` — validates setsid() creates new session

🤖 Generated with [Claude Code](https://claude.com/claude-code)