### PR TITLE
feat: network RX interrupt handling with kernel worker thread

### DIFF
--- a/arch/src/riscv64/cpu.rs
+++ b/arch/src/riscv64/cpu.rs
@@ -125,3 +125,31 @@ pub fn set_ret_to_kernel_mode(kernel_mode: bool) {
         csrc_sstatus(1 << SSTATUS_SPP);
     }
 }
+
+pub fn trigger_supervisor_software_interrupt() {
+    csrs_sip(1 << SIP_SSIP);
+}
+
+pub struct InterruptGuard {
+    was_enabled: bool,
+}
+
+impl InterruptGuard {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        let sstatus = read_sstatus();
+        let was_enabled = (sstatus & 0b10) != 0;
+        if was_enabled {
+            csrc_sstatus(0b10);
+        }
+        Self { was_enabled }
+    }
+}
+
+impl Drop for InterruptGuard {
+    fn drop(&mut self) {
+        if self.was_enabled {
+            csrs_sstatus(0b10);
+        }
+    }
+}

--- a/arch/src/stub/cpu.rs
+++ b/arch/src/stub/cpu.rs
@@ -65,3 +65,14 @@ pub fn is_in_kernel_mode() -> bool {
 
 #[allow(dead_code)]
 pub fn set_ret_to_kernel_mode(_kernel_mode: bool) {}
+
+#[allow(dead_code)]
+pub fn trigger_supervisor_software_interrupt() {}
+
+pub struct InterruptGuard;
+
+impl InterruptGuard {
+    pub fn new() -> Self {
+        Self
+    }
+}

--- a/doc/ai/ARCHITECTURE.md
+++ b/doc/ai/ARCHITECTURE.md
@@ -67,6 +67,7 @@ kernel_init()
   +-> enumerate_devices()           # Find PCI devices
   +-> NetworkDevice::initialize()   # Init VirtIO network
   +-> net::assign_network_device()  # Register network device
+  +-> kernel_tasks::create_worker_thread()  # Kernel async task executor
   +-> start_other_harts()           # Boot other CPUs
   +-> prepare_for_scheduling()      # Enter scheduler loop
 ```

--- a/doc/ai/INTERRUPTS.md
+++ b/doc/ai/INTERRUPTS.md
@@ -8,7 +8,7 @@ Interrupt handling in Solaya:
 3. **Timer** - Scheduling timer via SBI
 4. **Syscalls** - User ecall traps
 
-When in Kernel Mode, interrupts are always disabled. So we don't pre-empt the kernel.
+Interrupts are disabled while holding a Spinlock (via `InterruptGuard` in `SpinlockGuard`). The kernel worker thread runs with interrupts enabled between lock acquisitions. Kernel-mode threads are preemptible by timer interrupts.
 
 ## Trap Flow
 
@@ -70,8 +70,7 @@ User/Kernel Code
 
 Called on supervisor timer interrupt:
 ```rust
-#[unsafe(no_mangle)]
-extern "C" fn handle_timer_interrupt() {
+fn handle_timer_interrupt() {
     timer::wakeup_wakers();  // Wake sleeping threads
     Cpu::with_scheduler(|mut s| s.schedule());  // Reschedule
 }
@@ -79,19 +78,34 @@ extern "C" fn handle_timer_interrupt() {
 
 ### handle_external_interrupt()
 
-Called on external interrupt (UART):
+Called on external interrupt (UART or VirtIO network):
 ```rust
 fn handle_external_interrupt() {
     let plic_interrupt = PLIC.lock().get_next_pending()?;
-    // Read UART input
-    while let Some(input) = QEMU_UART.lock().read() {
-        match input {
-            3 => send_ctrl_c(),        // Ctrl+C
-            4 => dump_current_state(), // Ctrl+D
-            _ => STDIN_BUFFER.lock().push(input),
+    match plic_interrupt {
+        Uart => { /* read input, handle Ctrl+C/D */ }
+        VirtioNet => {
+            net::on_network_interrupt();  // Wakes network task wakers
+            // Worker thread polls ready tasks (not done in interrupt context)
         }
     }
-    PLIC.lock().complete_interrupt(plic_interrupt);
+}
+```
+
+### handle_supervisor_software_interrupt()
+
+Handles both IPIs (for thread kills) and worker thread sleep requests:
+```rust
+fn handle_supervisor_software_interrupt() {
+    let sleep_requested = kernel_tasks::take_sleep_request();
+    Cpu::with_scheduler(|mut s| {
+        if sleep_requested && is_current_worker {
+            // Save registers, suspend unless wakeup_pending
+            t.set_register_state(Cpu::read_trap_frame());
+            t.suspend_unless_wakeup_pending();
+        }
+        s.schedule();  // Always reschedule (handles IPIs too)
+    });
 }
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -113,7 +113,9 @@
               pkgs.tmux
               pwndbg.packages.${system}.default
               pkgs.typos-lsp
-            ] ++ basePackages;
+              pkgs.dtc
+            ]
+            ++ basePackages;
             shellHook = hook;
           }
         );

--- a/kernel/src/drivers/virtio/capability.rs
+++ b/kernel/src/drivers/virtio/capability.rs
@@ -7,7 +7,6 @@ pub const VIRTIO_PCI_CAP_COMMON_CFG: u8 = 1;
 #[allow(dead_code)]
 pub const VIRTIO_PCI_CAP_NOTIFY_CFG: u8 = 2;
 /* ISR Status */
-#[allow(dead_code)]
 pub const VIRTIO_PCI_CAP_ISR_CFG: u8 = 3;
 /* Device specific configuration */
 pub const VIRTIO_PCI_CAP_DEVICE_CFG: u8 = 4;

--- a/kernel/src/drivers/virtio/net/mod.rs
+++ b/kernel/src/drivers/virtio/net/mod.rs
@@ -3,8 +3,8 @@ use crate::{
     debug,
     drivers::virtio::{
         capability::{
-            VIRTIO_PCI_CAP_COMMON_CFG, VIRTIO_PCI_CAP_DEVICE_CFG, VIRTIO_PCI_CAP_NOTIFY_CFG,
-            virtio_pci_cap,
+            VIRTIO_PCI_CAP_COMMON_CFG, VIRTIO_PCI_CAP_DEVICE_CFG, VIRTIO_PCI_CAP_ISR_CFG,
+            VIRTIO_PCI_CAP_NOTIFY_CFG, virtio_pci_cap,
         },
         virtqueue::{BufferDirection, VirtQueue},
     },
@@ -59,7 +59,7 @@ impl NetworkDevice {
             && cs.subsystem_id().read() == VIRTIO_NETWORK_SUBSYSTEM_ID
     }
 
-    pub fn initialize(mut pci_device: PCIDevice) -> Result<Self, &'static str> {
+    pub fn initialize(mut pci_device: PCIDevice) -> Result<(Self, MMIO<u32>), &'static str> {
         let capabilities = pci_device.capabilities();
         let mut virtio_capabilities: Vec<MMIO<virtio_pci_cap>> = capabilities
             .filter(|cap| cap.id().read() == VIRTIO_VENDOR_SPECIFIC_CAPABILITY_ID)
@@ -114,6 +114,8 @@ impl NetworkDevice {
         let (mut receive_queue, transmit_queue) =
             Self::setup_virtqueues(&common_cfg, &notify_cfg, &notify_bar);
 
+        receive_queue.enable_interrupts();
+
         let mut device_status = common_cfg.device_status();
         device_status |= DEVICE_STATUS_DRIVER_OK;
 
@@ -128,6 +130,16 @@ impl NetworkDevice {
         );
 
         debug!("Device initialized: {:#x?}", device_status);
+
+        // Parse ISR status capability for interrupt acknowledgment
+        let isr_cfg_cap = virtio_capabilities
+            .iter()
+            .find(|cap| cap.cfg_type().read() == VIRTIO_PCI_CAP_ISR_CFG)
+            .ok_or("ISR configuration capability not found")?;
+
+        let isr_bar = pci_device.get_or_initialize_bar(isr_cfg_cap.bar().read());
+        let isr_status: MMIO<u32> =
+            MMIO::new((isr_bar.cpu_address + isr_cfg_cap.offset().read() as usize).as_usize());
 
         // Get net configuration
         let net_cfg_cap = virtio_capabilities
@@ -149,13 +161,21 @@ impl NetworkDevice {
 
         let mac_address = net_cfg.mac().read();
 
+        // Enable Bus Master for DMA and clear Interrupt Disable for legacy INTx
+        pci_device
+            .configuration_space_mut()
+            .set_command_register_bits(crate::pci::command_register::BUS_MASTER);
+        pci_device
+            .configuration_space_mut()
+            .clear_command_register_bits(crate::pci::command_register::INTERRUPT_DISABLE);
+
         info!(
             "Successfully initialized network device at {:p} with mac {}",
             *pci_device.configuration_space(),
             mac_address
         );
 
-        Ok(Self {
+        let device = Self {
             device: pci_device,
             common_cfg,
             net_cfg,
@@ -163,7 +183,9 @@ impl NetworkDevice {
             mac_address,
             receive_queue,
             transmit_queue,
-        })
+        };
+
+        Ok((device, isr_status))
     }
 
     fn reset_and_acknowledge(common_cfg: &MMIO<virtio_pci_common_cfg>) {

--- a/kernel/src/drivers/virtio/net/mod.rs
+++ b/kernel/src/drivers/virtio/net/mod.rs
@@ -51,6 +51,11 @@ const VIRTIO_VENDOR_ID: u16 = 0x1AF4;
 const VIRTIO_DEVICE_ID: core::ops::RangeInclusive<u16> = 0x1000..=0x107F;
 const VIRTIO_NETWORK_SUBSYSTEM_ID: u16 = 1;
 
+pub struct InitializedNetworkDevice {
+    pub device: NetworkDevice,
+    pub interrupt_status: MMIO<u32>,
+}
+
 impl NetworkDevice {
     pub fn is_virtio_net(device: &PCIDevice) -> bool {
         let cs = device.configuration_space();
@@ -59,7 +64,7 @@ impl NetworkDevice {
             && cs.subsystem_id().read() == VIRTIO_NETWORK_SUBSYSTEM_ID
     }
 
-    pub fn initialize(mut pci_device: PCIDevice) -> Result<(Self, MMIO<u32>), &'static str> {
+    pub fn initialize(mut pci_device: PCIDevice) -> Result<InitializedNetworkDevice, &'static str> {
         let capabilities = pci_device.capabilities();
         let mut virtio_capabilities: Vec<MMIO<virtio_pci_cap>> = capabilities
             .filter(|cap| cap.id().read() == VIRTIO_VENDOR_SPECIFIC_CAPABILITY_ID)
@@ -185,7 +190,10 @@ impl NetworkDevice {
             transmit_queue,
         };
 
-        Ok((device, isr_status))
+        Ok(InitializedNetworkDevice {
+            device,
+            interrupt_status: isr_status,
+        })
     }
 
     fn reset_and_acknowledge(common_cfg: &MMIO<virtio_pci_common_cfg>) {

--- a/kernel/src/drivers/virtio/virtqueue.rs
+++ b/kernel/src/drivers/virtio/virtqueue.rs
@@ -189,6 +189,11 @@ impl<const QUEUE_SIZE: usize> VirtQueue<QUEUE_SIZE> {
         return_buffers
     }
 
+    pub fn enable_interrupts(&mut self) {
+        self.driver_area.flags = 0;
+        arch::cpu::memory_fence();
+    }
+
     pub fn notify(&mut self) {
         if let Some(notify) = &mut self.notify {
             notify.write(self.queue_index);

--- a/kernel/src/interrupts/plic.rs
+++ b/kernel/src/interrupts/plic.rs
@@ -1,3 +1,5 @@
+use core::sync::atomic::{AtomicU32, Ordering};
+
 use crate::{
     info,
     klibc::{MMIO, Spinlock, runtime_initialized::RuntimeInitializedData},
@@ -29,7 +31,15 @@ impl Plic {
         }
     }
     fn enable(&mut self, interrupt_id: u32) {
-        self.enable_register |= 1 << interrupt_id;
+        let word_offset = interrupt_id / 32;
+        let bit = interrupt_id % 32;
+        // SAFETY: Each 32-bit word in the enable register array covers 32
+        // interrupt IDs. word_offset selects the correct word within the
+        // PLIC enable register region.
+        unsafe {
+            let mut reg = self.enable_register.add(word_offset as usize);
+            reg |= 1 << bit;
+        }
     }
 
     fn set_priority(&mut self, interrupt_id: u32, priority: u32) {
@@ -54,6 +64,7 @@ impl Plic {
         match open_interrupt {
             0 => None,
             UART_INTERRUPT_NUMBER => Some(InterruptSource::Uart),
+            id if id == VIRTIO_NET_IRQ.load(Ordering::Relaxed) => Some(InterruptSource::VirtioNet),
             id => panic!("Unknown PLIC interrupt source ID {id}"),
         }
     }
@@ -61,6 +72,7 @@ impl Plic {
     pub fn complete_interrupt(&mut self, source: InterruptSource) {
         let interrupt_id = match source {
             InterruptSource::Uart => UART_INTERRUPT_NUMBER,
+            InterruptSource::VirtioNet => VIRTIO_NET_IRQ.load(Ordering::Relaxed),
         };
         self.claim_complete_register.write(interrupt_id);
     }
@@ -69,10 +81,12 @@ impl Plic {
 pub static PLIC: RuntimeInitializedData<Spinlock<Plic>> = RuntimeInitializedData::new();
 
 const UART_INTERRUPT_NUMBER: u32 = 10;
+static VIRTIO_NET_IRQ: AtomicU32 = AtomicU32::new(0);
 
 #[derive(PartialEq, Eq)]
 pub enum InterruptSource {
     Uart,
+    VirtioNet,
 }
 
 pub fn init_uart_interrupt(cpu_id: CpuId) {
@@ -84,4 +98,12 @@ pub fn init_uart_interrupt(cpu_id: CpuId) {
     plic.set_threshold(0);
     plic.enable(UART_INTERRUPT_NUMBER);
     plic.set_priority(UART_INTERRUPT_NUMBER, 1);
+}
+
+pub fn init_virtio_net_interrupt(interrupt_id: u32) {
+    info!("Initializing plic virtio net interrupt (IRQ {interrupt_id})");
+    VIRTIO_NET_IRQ.store(interrupt_id, Ordering::Relaxed);
+    let mut plic = PLIC.lock();
+    plic.enable(interrupt_id);
+    plic.set_priority(interrupt_id, 1);
 }

--- a/kernel/src/interrupts/trap.rs
+++ b/kernel/src/interrupts/trap.rs
@@ -53,7 +53,6 @@ extern "C" fn handle_trap() {
 
 fn handle_timer_interrupt() {
     timer::wakeup_wakers();
-    crate::processes::kernel_tasks::poll_ready_tasks();
     Cpu::with_scheduler(|mut s| s.schedule());
     assert_sepc_not_in_trap_handler();
 }
@@ -97,7 +96,6 @@ fn handle_external_interrupt() {
             plic.complete_interrupt(plic_interrupt);
             drop(plic);
             crate::net::on_network_interrupt();
-            crate::processes::kernel_tasks::poll_ready_tasks();
         }
     }
 }
@@ -267,10 +265,24 @@ fn handle_exception() {
 }
 
 fn handle_supervisor_software_interrupt() {
-    // This interrupt is fired when we kill a thread
-    // It could be that our cpu is currently running this
-    // thread, therefore, reschedule.
-    Cpu::with_scheduler(|mut s| s.schedule());
+    let sleep_requested = crate::processes::kernel_tasks::take_sleep_request();
+
+    Cpu::with_scheduler(|mut s| {
+        if sleep_requested {
+            let is_worker = s
+                .get_current_thread()
+                .with_lock(|t| crate::processes::kernel_tasks::is_current_worker_tid(t.get_tid()));
+            if is_worker {
+                s.get_current_thread().with_lock(|mut t| {
+                    t.set_register_state(Cpu::read_trap_frame());
+                    t.set_program_counter(VirtAddr::new(arch::cpu::read_sepc()));
+                    t.suspend_unless_wakeup_pending();
+                });
+            }
+        }
+        s.schedule();
+    });
+
     arch::cpu::clear_supervisor_software_interrupt();
     assert_sepc_not_in_trap_handler();
 }

--- a/kernel/src/interrupts/trap.rs
+++ b/kernel/src/interrupts/trap.rs
@@ -53,6 +53,7 @@ extern "C" fn handle_trap() {
 
 fn handle_timer_interrupt() {
     timer::wakeup_wakers();
+    crate::processes::kernel_tasks::poll_ready_tasks();
     Cpu::with_scheduler(|mut s| s.schedule());
     assert_sepc_not_in_trap_handler();
 }
@@ -64,34 +65,40 @@ fn handle_external_interrupt() {
         Some(i) => i,
         None => return,
     };
-    assert!(
-        plic_interrupt == InterruptSource::Uart,
-        "Plic interrupt should be uart."
-    );
 
-    let mut ctrl_c = false;
-    let mut ctrl_d = false;
-    {
-        let uart = QEMU_UART.lock();
-        while let Some(input) = uart.read() {
-            match input {
-                3 => ctrl_c = true,
-                4 => ctrl_d = true,
-                _ => STDIN_BUFFER.lock().push(input),
+    match plic_interrupt {
+        InterruptSource::Uart => {
+            let mut ctrl_c = false;
+            let mut ctrl_d = false;
+            {
+                let uart = QEMU_UART.lock();
+                while let Some(input) = uart.read() {
+                    match input {
+                        3 => ctrl_c = true,
+                        4 => ctrl_d = true,
+                        _ => STDIN_BUFFER.lock().push(input),
+                    }
+                }
+            }
+
+            plic.complete_interrupt(plic_interrupt);
+            drop(plic);
+
+            if ctrl_c {
+                Cpu::with_scheduler(|mut s| {
+                    s.send_ctrl_c();
+                });
+            }
+            if ctrl_d {
+                crate::debugging::dump_current_state();
             }
         }
-    }
-
-    plic.complete_interrupt(plic_interrupt);
-    drop(plic);
-
-    if ctrl_c {
-        Cpu::with_scheduler(|mut s| {
-            s.send_ctrl_c();
-        });
-    }
-    if ctrl_d {
-        crate::debugging::dump_current_state();
+        InterruptSource::VirtioNet => {
+            plic.complete_interrupt(plic_interrupt);
+            drop(plic);
+            crate::net::on_network_interrupt();
+            crate::processes::kernel_tasks::poll_ready_tasks();
+        }
     }
 }
 

--- a/kernel/src/klibc/mmio.rs
+++ b/kernel/src/klibc/mmio.rs
@@ -93,6 +93,10 @@ impl<T: Number + BitAnd<T, Output = T>> BitAndAssign<T> for MMIO<T> {
 // pointer to another thread is safe; callers must provide synchronization
 // for concurrent access (e.g., Spinlock).
 unsafe impl<T> Send for MMIO<T> {}
+// SAFETY: MMIO performs volatile reads/writes to hardware registers. Sharing
+// the pointer between threads is safe; concurrent access semantics are
+// defined by the hardware (e.g., reading ISR status is idempotent).
+unsafe impl<T> Sync for MMIO<T> {}
 
 impl<T> core::fmt::Pointer for MMIO<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/kernel/src/klibc/spinlock.rs
+++ b/kernel/src/klibc/spinlock.rs
@@ -32,18 +32,23 @@ impl<T> Spinlock<T> {
     }
 
     pub fn try_with_lock<'a, R>(&'a self, f: impl FnOnce(SpinlockGuard<'a, T>) -> R) -> Option<R> {
+        let interrupt_guard = arch::cpu::InterruptGuard::new();
         let value = self
             .locked
             .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed);
         if value.is_ok() {
             self.set_owner();
-            let lock = SpinlockGuard { spinlock: self };
+            let lock = SpinlockGuard {
+                spinlock: self,
+                _interrupt_guard: interrupt_guard,
+            };
             return Some(f(lock));
         }
         None
     }
 
     pub fn lock(&self) -> SpinlockGuard<'_, T> {
+        let interrupt_guard = arch::cpu::InterruptGuard::new();
         self.detect_same_cpu_deadlock();
         let mut spin_count: u64 = 0;
         while self
@@ -56,7 +61,10 @@ impl<T> Spinlock<T> {
             core::hint::spin_loop();
         }
         self.set_owner();
-        SpinlockGuard { spinlock: self }
+        SpinlockGuard {
+            spinlock: self,
+            _interrupt_guard: interrupt_guard,
+        }
     }
 
     #[cfg(all(target_arch = "riscv64", not(miri)))]
@@ -129,6 +137,7 @@ unsafe impl<T: Send> Send for Spinlock<T> {}
 
 pub struct SpinlockGuard<'a, T> {
     spinlock: &'a Spinlock<T>,
+    _interrupt_guard: arch::cpu::InterruptGuard,
 }
 
 impl<T> Drop for SpinlockGuard<'_, T> {

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -173,6 +173,8 @@ extern "C" fn kernel_init(hart_id: usize, device_tree_pointer: *const ()) -> ! {
         processes::kernel_tasks::spawn(net::network_rx_task());
     }
 
+    processes::kernel_tasks::create_worker_thread();
+
     info!("kernel_init done! Starting other harts");
 
     start_other_harts(hart_id, num_cpus);

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -165,10 +165,10 @@ extern "C" fn kernel_init(hart_id: usize, device_tree_pointer: *const ()) -> ! {
     if let Some(index) = virtio_net {
         let device = pci_devices.swap_remove(index);
         let plic_irq = device.plic_interrupt_id();
-        let (network_device, isr_status) = drivers::virtio::net::NetworkDevice::initialize(device)
+        let init = drivers::virtio::net::NetworkDevice::initialize(device)
             .expect("Initialization must work.");
-        net::assign_network_device(network_device);
-        net::init_isr_status(isr_status);
+        net::assign_network_device(init.device);
+        net::init_isr_status(init.interrupt_status);
         plic::init_virtio_net_interrupt(plic_irq);
         processes::kernel_tasks::spawn(net::network_rx_task());
     }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -164,9 +164,13 @@ extern "C" fn kernel_init(hart_id: usize, device_tree_pointer: *const ()) -> ! {
         .position(drivers::virtio::net::NetworkDevice::is_virtio_net);
     if let Some(index) = virtio_net {
         let device = pci_devices.swap_remove(index);
-        let network_device = drivers::virtio::net::NetworkDevice::initialize(device)
+        let plic_irq = device.plic_interrupt_id();
+        let (network_device, isr_status) = drivers::virtio::net::NetworkDevice::initialize(device)
             .expect("Initialization must work.");
         net::assign_network_device(network_device);
+        net::init_isr_status(isr_status);
+        plic::init_virtio_net_interrupt(plic_irq);
+        processes::kernel_tasks::spawn(net::network_rx_task());
     }
 
     info!("kernel_init done! Starting other harts");

--- a/kernel/src/net/mod.rs
+++ b/kernel/src/net/mod.rs
@@ -1,11 +1,17 @@
-use core::{cell::LazyCell, net::Ipv4Addr};
+use core::{
+    cell::LazyCell,
+    net::Ipv4Addr,
+    pin::Pin,
+    sync::atomic::{AtomicU64, Ordering},
+    task::{Context, Poll, Waker},
+};
 
 use alloc::vec::Vec;
 
 use crate::{
     debug,
     drivers::virtio::net::NetworkDevice,
-    klibc::Spinlock,
+    klibc::{MMIO, Spinlock, runtime_initialized::RuntimeInitializedData},
     net::{ipv4::IpV4Header, udp::UdpHeader},
 };
 
@@ -31,6 +37,70 @@ static NETWORK_STACK: NetworkStack = NetworkStack {
     open_sockets: Spinlock::new(LazyCell::new(OpenSockets::new)),
 };
 
+static ISR_STATUS: RuntimeInitializedData<MMIO<u32>> = RuntimeInitializedData::new();
+static NETWORK_INTERRUPT_COUNTER: AtomicU64 = AtomicU64::new(0);
+static NETWORK_INTERRUPT_WAKERS: Spinlock<Vec<Waker>> = Spinlock::new(Vec::new());
+
+pub fn init_isr_status(isr: MMIO<u32>) {
+    ISR_STATUS.initialize(isr);
+}
+
+pub fn on_network_interrupt() {
+    // Reading ISR status acknowledges the interrupt on the device side
+    let _isr = ISR_STATUS.read();
+    NETWORK_INTERRUPT_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let wakers: Vec<Waker> = NETWORK_INTERRUPT_WAKERS.lock().drain(..).collect();
+    for waker in wakers {
+        waker.wake();
+    }
+}
+
+struct NetworkInterruptWait {
+    seen_counter: u64,
+    registered: bool,
+}
+
+impl NetworkInterruptWait {
+    fn new(seen_counter: u64) -> Self {
+        Self {
+            seen_counter,
+            registered: false,
+        }
+    }
+}
+
+impl Future for NetworkInterruptWait {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let current = NETWORK_INTERRUPT_COUNTER.load(Ordering::SeqCst);
+        if current != self.seen_counter {
+            return Poll::Ready(());
+        }
+        if !self.registered {
+            NETWORK_INTERRUPT_WAKERS.lock().push(cx.waker().clone());
+            self.registered = true;
+            // Double-check after registering to prevent lost wakeups
+            let current = NETWORK_INTERRUPT_COUNTER.load(Ordering::SeqCst);
+            if current != self.seen_counter {
+                return Poll::Ready(());
+            }
+        }
+        Poll::Pending
+    }
+}
+
+pub async fn network_rx_task() {
+    loop {
+        let seen = NETWORK_INTERRUPT_COUNTER.load(Ordering::SeqCst);
+        let count = receive_and_process_packets();
+        if count > 0 {
+            sockets::wake_socket_waiters();
+        }
+        NetworkInterruptWait::new(seen).await;
+    }
+}
+
 pub fn ip_addr() -> Ipv4Addr {
     NETWORK_STACK.ip_addr
 }
@@ -43,7 +113,7 @@ pub fn assign_network_device(device: NetworkDevice) {
     *NETWORK_STACK.device.lock() = Some(device);
 }
 
-pub fn receive_and_process_packets() {
+fn receive_and_process_packets() -> usize {
     let packets = NETWORK_STACK
         .device
         .lock()
@@ -51,9 +121,11 @@ pub fn receive_and_process_packets() {
         .expect("There must be a configured network device.")
         .receive_packets();
 
+    let count = packets.len();
     for packet in packets {
         process_packet(packet);
     }
+    count
 }
 
 pub fn send_packet(packet: Vec<u8>) {

--- a/kernel/src/net/sockets.rs
+++ b/kernel/src/net/sockets.rs
@@ -1,4 +1,9 @@
-use core::net::Ipv4Addr;
+use core::{
+    net::Ipv4Addr,
+    pin::Pin,
+    sync::atomic::{AtomicU64, Ordering},
+    task::{Context, Poll, Waker},
+};
 
 use alloc::{
     collections::{BTreeMap, VecDeque, btree_map::Entry},
@@ -7,6 +12,56 @@ use alloc::{
 };
 
 use crate::{debug, klibc::Spinlock};
+
+static SOCKET_DATA_COUNTER: AtomicU64 = AtomicU64::new(0);
+static SOCKET_WAITERS: Spinlock<Vec<Waker>> = Spinlock::new(Vec::new());
+
+pub fn wake_socket_waiters() {
+    SOCKET_DATA_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let wakers: Vec<Waker> = SOCKET_WAITERS.lock().drain(..).collect();
+    for waker in wakers {
+        waker.wake();
+    }
+}
+
+pub fn socket_data_counter() -> u64 {
+    SOCKET_DATA_COUNTER.load(Ordering::SeqCst)
+}
+
+pub struct SocketDataWait {
+    seen_counter: u64,
+    registered: bool,
+}
+
+impl SocketDataWait {
+    pub fn new(seen_counter: u64) -> Self {
+        Self {
+            seen_counter,
+            registered: false,
+        }
+    }
+}
+
+impl Future for SocketDataWait {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let current = SOCKET_DATA_COUNTER.load(Ordering::SeqCst);
+        if current != self.seen_counter {
+            return Poll::Ready(());
+        }
+        if !self.registered {
+            SOCKET_WAITERS.lock().push(cx.waker().clone());
+            self.registered = true;
+            // Double-check after registering to prevent lost wakeups
+            let current = SOCKET_DATA_COUNTER.load(Ordering::SeqCst);
+            if current != self.seen_counter {
+                return Poll::Ready(());
+            }
+        }
+        Poll::Pending
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Port(u16);

--- a/kernel/src/pci/mod.rs
+++ b/kernel/src/pci/mod.rs
@@ -33,6 +33,8 @@ const CAPABILITY_POINTER_MASK: u8 = !0x3;
 pub mod command_register {
     pub const IO_SPACE: u16 = 1 << 0;
     pub const MEMORY_SPACE: u16 = 1 << 1;
+    pub const BUS_MASTER: u16 = 1 << 2;
+    pub const INTERRUPT_DISABLE: u16 = 1 << 10;
 }
 
 mmio_struct! {
@@ -116,6 +118,7 @@ impl Iterator for PciCapabilityIter<'_> {
 pub struct PCIDevice {
     configuration_space: MMIO<GeneralDevicePciHeader>,
     initialized_bars: BTreeMap<u8, PCIAllocatedSpace>,
+    device_number: u8,
 }
 
 impl PCIDevice {
@@ -127,9 +130,18 @@ impl PCIDevice {
         &self.configuration_space
     }
 
+    // QEMU riscv virt PCI interrupt mapping: IRQ = 32 + (device + pin - 1) % 4
+    // where pin is the PCI INTx pin (1=INTA, 2=INTB, etc.)
+    pub fn plic_interrupt_id(&self) -> u32 {
+        const PLIC_PCI_BASE: u32 = 32;
+        // VirtIO PCI devices use INTA (pin 1)
+        let pin: u32 = 1;
+        PLIC_PCI_BASE + (u32::from(self.device_number) + pin - 1) % 4
+    }
+
     /// # Safety
     /// `address` must point to a valid PCI configuration space MMIO region.
-    unsafe fn try_new(address: PciCpuAddr) -> Option<Self> {
+    unsafe fn try_new(address: PciCpuAddr, device_number: u8) -> Option<Self> {
         let pci_device: MMIO<GeneralDevicePciHeader> = MMIO::new(address.as_usize());
         if pci_device.vendor_id().read() == INVALID_VENDOR_ID {
             return None;
@@ -138,6 +150,7 @@ impl PCIDevice {
         Some(Self {
             configuration_space: pci_device,
             initialized_bars: BTreeMap::new(),
+            device_number,
         })
     }
 
@@ -224,7 +237,7 @@ pub fn enumerate_devices(pci_information: &PCIInformation) -> Vec<PCIDevice> {
                 );
                 // SAFETY: address is computed from the PCI host bridge base
                 // and valid bus/device/function numbers.
-                let maybe_device = unsafe { PCIDevice::try_new(address) };
+                let maybe_device = unsafe { PCIDevice::try_new(address, device) };
                 if let Some(device) = maybe_device {
                     let vendor_id = device.configuration_space.vendor_id().read();
                     let device_id = device.configuration_space.device_id().read();

--- a/kernel/src/processes/kernel_tasks.rs
+++ b/kernel/src/processes/kernel_tasks.rs
@@ -1,0 +1,56 @@
+use alloc::{
+    collections::{BTreeMap, VecDeque},
+    sync::Arc,
+    task::Wake,
+};
+use core::{
+    sync::atomic::{AtomicUsize, Ordering},
+    task::{Context, Waker},
+};
+
+use crate::klibc::Spinlock;
+
+use super::task::Task;
+
+static TASKS: Spinlock<BTreeMap<usize, Task<()>>> = Spinlock::new(BTreeMap::new());
+static READY_IDS: Spinlock<VecDeque<usize>> = Spinlock::new(VecDeque::new());
+static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+
+pub fn spawn(future: impl Future<Output = ()> + Send + 'static) {
+    let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    TASKS.lock().insert(id, Task::new(future));
+    READY_IDS.lock().push_back(id);
+}
+
+pub fn poll_ready_tasks() {
+    loop {
+        let id = match READY_IDS.lock().pop_front() {
+            Some(id) => id,
+            None => return,
+        };
+        let mut task = match TASKS.lock().remove(&id) {
+            Some(task) => task,
+            None => {
+                // Task is being polled on another CPU. Re-queue so the
+                // wakeup isn't lost; return to avoid spinning.
+                READY_IDS.lock().push_back(id);
+                return;
+            }
+        };
+        let waker = Waker::from(Arc::new(KernelTaskWaker { task_id: id }));
+        let mut cx = Context::from_waker(&waker);
+        if task.poll(&mut cx).is_pending() {
+            TASKS.lock().insert(id, task);
+        }
+    }
+}
+
+struct KernelTaskWaker {
+    task_id: usize,
+}
+
+impl Wake for KernelTaskWaker {
+    fn wake(self: Arc<Self>) {
+        READY_IDS.lock().push_back(self.task_id);
+    }
+}

--- a/kernel/src/processes/kernel_tasks.rs
+++ b/kernel/src/processes/kernel_tasks.rs
@@ -3,26 +3,42 @@ use alloc::{
     sync::Arc,
     task::Wake,
 };
+use common::{pid::Tid, syscalls::trap_frame::TrapFrame};
 use core::{
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
     task::{Context, Waker},
 };
 
-use crate::klibc::Spinlock;
+use crate::{
+    klibc::Spinlock,
+    memory::{VirtAddr, page_tables::RootPageTableHolder},
+    processes::brk::Brk,
+};
 
-use super::task::Task;
+use super::{
+    process::POWERSAVE_TID,
+    process_table,
+    task::Task,
+    thread::{ThreadRef, get_next_tid},
+};
+
+const WORKER_STACK_SIZE: usize = 16 * 1024;
 
 static TASKS: Spinlock<BTreeMap<usize, Task<()>>> = Spinlock::new(BTreeMap::new());
 static READY_IDS: Spinlock<VecDeque<usize>> = Spinlock::new(VecDeque::new());
 static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+static WORKER_THREAD: Spinlock<Option<ThreadRef>> = Spinlock::new(None);
+static WORKER_SLEEP_REQUESTED: AtomicBool = AtomicBool::new(false);
+static WORKER_TID: AtomicU64 = AtomicU64::new(u64::MAX);
 
 pub fn spawn(future: impl Future<Output = ()> + Send + 'static) {
     let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
     TASKS.lock().insert(id, Task::new(future));
     READY_IDS.lock().push_back(id);
+    wake_worker_thread();
 }
 
-pub fn poll_ready_tasks() {
+fn poll_ready_tasks() {
     loop {
         let id = match READY_IDS.lock().pop_front() {
             Some(id) => id,
@@ -31,8 +47,8 @@ pub fn poll_ready_tasks() {
         let mut task = match TASKS.lock().remove(&id) {
             Some(task) => task,
             None => {
-                // Task is being polled on another CPU. Re-queue so the
-                // wakeup isn't lost; return to avoid spinning.
+                // Waker fired while this task was being polled. Re-queue
+                // so the wakeup isn't lost; return to avoid spinning.
                 READY_IDS.lock().push_back(id);
                 return;
             }
@@ -45,6 +61,62 @@ pub fn poll_ready_tasks() {
     }
 }
 
+pub fn create_worker_thread() {
+    let stack = alloc::boxed::Box::leak(alloc::vec![0u8; WORKER_STACK_SIZE].into_boxed_slice());
+    let stack_top = stack.as_ptr() as usize + WORKER_STACK_SIZE;
+
+    let page_table = RootPageTableHolder::new_with_kernel_mapping(true);
+
+    let mut register_state = TrapFrame::zero();
+    register_state[common::syscalls::trap_frame::Register::sp] = stack_top;
+
+    let tid = get_next_tid();
+    let thread = super::thread::Thread::new_process(
+        "kernel_worker",
+        tid,
+        register_state,
+        page_table,
+        VirtAddr::new(kernel_worker_entry as *const () as usize),
+        alloc::vec![],
+        true,
+        Brk::empty(),
+        POWERSAVE_TID,
+        tid,
+        tid,
+    );
+
+    WORKER_TID.store(tid.as_u64(), Ordering::Relaxed);
+    *WORKER_THREAD.lock() = Some(thread.clone());
+    process_table::RUN_QUEUE.lock().push_back(thread);
+}
+
+extern "C" fn kernel_worker_entry() -> ! {
+    loop {
+        poll_ready_tasks();
+        if READY_IDS.lock().is_empty() {
+            WORKER_SLEEP_REQUESTED.store(true, Ordering::Release);
+            arch::cpu::trigger_supervisor_software_interrupt();
+        }
+    }
+}
+
+pub fn take_sleep_request() -> bool {
+    WORKER_SLEEP_REQUESTED.swap(false, Ordering::Acquire)
+}
+
+pub fn is_current_worker_tid(tid: Tid) -> bool {
+    tid.as_u64() == WORKER_TID.load(Ordering::Relaxed)
+}
+
+fn wake_worker_thread() {
+    if let Some(thread) = WORKER_THREAD.lock().as_ref() {
+        let woke = thread.lock().wake_up();
+        if woke {
+            process_table::RUN_QUEUE.lock().push_back(thread.clone());
+        }
+    }
+}
+
 struct KernelTaskWaker {
     task_id: usize,
 }
@@ -52,5 +124,6 @@ struct KernelTaskWaker {
 impl Wake for KernelTaskWaker {
     fn wake(self: Arc<Self>) {
         READY_IDS.lock().push_back(self.task_id);
+        wake_worker_thread();
     }
 }

--- a/kernel/src/processes/mod.rs
+++ b/kernel/src/processes/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod brk;
 pub mod fd_table;
 pub mod futex;
+pub mod kernel_tasks;
 pub(crate) mod loader;
 pub mod process;
 pub mod process_table;

--- a/kernel/src/processes/thread.rs
+++ b/kernel/src/processes/thread.rs
@@ -334,6 +334,14 @@ impl Thread {
         false
     }
 
+    pub fn suspend_unless_wakeup_pending(&mut self) {
+        if self.wakeup_pending {
+            self.wakeup_pending = false;
+        } else {
+            self.suspend();
+        }
+    }
+
     fn suspend(&mut self) {
         assert_ne!(
             self.state,

--- a/kernel/src/syscalls/linux.rs
+++ b/kernel/src/syscalls/linux.rs
@@ -790,47 +790,50 @@ impl LinuxSyscalls for LinuxSyscallHandler {
         src_addr: LinuxUserspaceArg<Option<*mut u8>>,
         addrlen: LinuxUserspaceArg<Option<*mut c_uint>>,
     ) -> Result<isize, Errno> {
-        net::receive_and_process_packets();
-
-        let socket = self
+        let (socket, is_nonblocking) = self
             .current_process
             .with_lock(|p| {
                 p.fd_table().get(fd).and_then(|e| match &e.descriptor {
-                    FileDescriptor::UdpSocket(s) => Some(s.clone()),
+                    FileDescriptor::UdpSocket(s) => Some((s.clone(), e.flags.is_nonblocking())),
                     _ => None,
                 })
             })
             .ok_or(Errno::EBADF)?;
 
         let mut tmp_buf = alloc::vec![0u8; len];
-        let result = socket.lock().get_datagram(&mut tmp_buf);
 
-        match result {
-            // TODO: blocking recvfrom should wait for data instead of returning EAGAIN
-            None => Err(Errno::EAGAIN),
-            Some((bytes_read, from_ip, from_port)) => {
-                buf.write_slice(&tmp_buf[..bytes_read])?;
-
-                if src_addr.arg_nonzero() {
-                    let sin = sockaddr_in {
-                        sin_family: u16::try_from(AF_INET).expect("AF_INET fits in u16"),
-                        sin_port: from_port.as_u16().to_be(),
-                        sin_addr: headers::socket::in_addr {
-                            s_addr: u32::from(from_ip).to_be(),
-                        },
-                        sin_zero: [0; 8],
-                    };
-                    let src_writer =
-                        LinuxUserspaceArg::<*mut u8>::new(src_addr.raw_arg(), self.get_process());
-                    src_writer.write_slice(sin.as_slice())?;
-                    let addrlen_val = c_uint::try_from(core::mem::size_of::<sockaddr_in>())
-                        .expect("sockaddr_in size fits in c_uint");
-                    addrlen.write_if_not_none(addrlen_val)?;
-                }
-
-                Ok(bytes_read as isize)
+        let result = loop {
+            let seen = net::sockets::socket_data_counter();
+            if let Some(result) = socket.lock().get_datagram(&mut tmp_buf) {
+                break result;
             }
+            if is_nonblocking {
+                return Err(Errno::EAGAIN);
+            }
+            net::sockets::SocketDataWait::new(seen).await;
+        };
+
+        let (bytes_read, from_ip, from_port) = result;
+        buf.write_slice(&tmp_buf[..bytes_read])?;
+
+        if src_addr.arg_nonzero() {
+            let sin = sockaddr_in {
+                sin_family: u16::try_from(AF_INET).expect("AF_INET fits in u16"),
+                sin_port: from_port.as_u16().to_be(),
+                sin_addr: headers::socket::in_addr {
+                    s_addr: u32::from(from_ip).to_be(),
+                },
+                sin_zero: [0; 8],
+            };
+            let src_writer =
+                LinuxUserspaceArg::<*mut u8>::new(src_addr.raw_arg(), self.get_process());
+            src_writer.write_slice(sin.as_slice())?;
+            let addrlen_val = c_uint::try_from(core::mem::size_of::<sockaddr_in>())
+                .expect("sockaddr_in size fits in c_uint");
+            addrlen.write_if_not_none(addrlen_val)?;
         }
+
+        Ok(bytes_read as isize)
     }
 
     async fn wait4(

--- a/todo/overview.md
+++ b/todo/overview.md
@@ -11,11 +11,10 @@ This document contains research summaries for planned future enhancements. Each 
 5. [Feasible Coreutils](#5-feasible-coreutils)
 6. [QEMU Framebuffer](#6-qemu-framebuffer)
 7. [Port Doom](#7-port-doom)
-8. [Async Network Reception with Interrupts](#8-async-network-reception-with-interrupts)
-9. [DHCP Client](#9-dhcp-client)
-10. [Minimal TCP Implementation](#10-minimal-tcp-implementation)
-11. [Dynamic Linking](#11-dynamic-linking)
-12. [QEMU Random Device Driver](#12-qemu-random-device-driver)
+8. [DHCP Client](#8-dhcp-client)
+9. [Minimal TCP Implementation](#9-minimal-tcp-implementation)
+10. [Dynamic Linking](#10-dynamic-linking)
+11. [QEMU Random Device Driver](#11-qemu-random-device-driver)
 
 ---
 
@@ -440,68 +439,7 @@ qemu-system-riscv64 \
 
 ---
 
-## 8. Async Network Reception with Interrupts
-
-**Complexity:** Low to Medium
-
-### Current Polling Implementation
-`recvfrom()` actively polls network card via `net::receive_and_process_packets()`, returns `EAGAIN` if no data.
-
-**Problem:** Wasteful, prevents true async blocking.
-
-### Proposed Implementation
-
-**Model:** Follow existing timer-based sleep pattern (`kernel/src/processes/timer.rs`)
-
-**Key Components:**
-
-1. **Enable VirtIO Interrupts** (currently disabled)
-   - Clear `VIRTQ_AVAIL_F_NO_INTERRUPT` flag in virtqueue.rs:238
-   - Configure MSIX vectors in VirtIO driver
-
-2. **Create Waker Queue**
-```rust
-static RECV_WAITERS: Spinlock<BTreeMap<Port, Vec<Waker>>> = ...;
-```
-
-3. **RecvWait Future**
-```rust
-impl Future for RecvWait {
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<()> {
-        if packet_available(self.port) {
-            return Poll::Ready(());
-        }
-        if !self.registered {
-            RECV_WAITERS.lock().insert(self.port, cx.waker().clone());
-            self.registered = true;
-        }
-        Poll::Pending
-    }
-}
-```
-
-4. **PLIC Interrupt Handler**
-- Detect VirtIO network interrupt
-- Call `handle_network_interrupt()` which processes packets and wakes waiters
-
-### Files to Modify
-- `kernel/src/drivers/virtio/net/mod.rs` - Enable interrupts
-- `kernel/src/interrupts/plic.rs` - Add VirtIO interrupt source
-- `kernel/src/interrupts/trap.rs` - Handle network interrupts
-- `kernel/src/net/sockets.rs` - Add waker registration
-- `kernel/src/syscalls/linux.rs` - Make `recvfrom()` truly async
-
-### Benefits
-- Eliminates wasteful polling
-- Threads truly sleep waiting for network data
-- Better CPU utilization
-- Aligns with existing async infrastructure
-
-**Estimated effort:** 3-5 days
-
----
-
-## 9. DHCP Client
+## 8. DHCP Client
 
 **Complexity:** Low to Medium
 
@@ -573,7 +511,7 @@ async fn sys_solaya_set_ip(addr_u32: u32) -> Result<isize, Errno> {
 
 ---
 
-## 10. Minimal TCP Implementation
+## 9. Minimal TCP Implementation
 
 **Complexity:** Medium to High
 
@@ -644,7 +582,7 @@ Four-way handshake (FIN, ACK, FIN, ACK) - can optimize to three-way.
 
 ---
 
-## 11. Dynamic Linking
+## 10. Dynamic Linking
 
 **Complexity:** Medium to High
 
@@ -727,7 +665,7 @@ Four-way handshake (FIN, ACK, FIN, ACK) - can optimize to three-way.
 
 ---
 
-## 12. QEMU Random Device Driver
+## 11. QEMU Random Device Driver
 
 **Complexity:** Low to Medium
 
@@ -808,24 +746,23 @@ pub fn is_virtio_rng(device: &PCIDevice) -> bool {
 ## Dependencies and Recommended Order
 
 ### Phase 1: Foundation (Critical Infrastructure)
-1. **#8 - Async Network with Interrupts** (Better performance)
-2. **#12 - QEMU Random Device** (Security foundation)
+1. **#11 - QEMU Random Device** (Security foundation)
 
 ### Phase 2: Storage and Filesystems
-3. **#3 - QEMU Block Device Driver** (Prerequisite for filesystems)
-4. **#2 - Virtual File System** (Core abstraction)
-5. **#4 - ext2 Filesystem** (Persistent storage)
-6. **#5 - Coreutils** (User-facing utilities)
+2. **#3 - QEMU Block Device Driver** (Prerequisite for filesystems)
+3. **#2 - Virtual File System** (Core abstraction)
+4. **#4 - ext2 Filesystem** (Persistent storage)
+5. **#5 - Coreutils** (User-facing utilities)
 
 ### Phase 3: Networking Enhancements
-7. **#9 - DHCP Client** (Network configuration)
-8. **#10 - Minimal TCP** (Protocol expansion)
+6. **#8 - DHCP Client** (Network configuration)
+7. **#9 - Minimal TCP** (Protocol expansion)
 
 ### Phase 4: Advanced Features
-9. **#1 - Linux Signals** (Process control)
-10. **#11 - Dynamic Linking** (Shared libraries)
-11. **#6 - Framebuffer** (Graphics foundation)
-12. **#7 - Port Doom** (Showcase project)
+8. **#1 - Linux Signals** (Process control)
+9. **#10 - Dynamic Linking** (Shared libraries)
+10. **#6 - Framebuffer** (Graphics foundation)
+11. **#7 - Port Doom** (Showcase project)
 
 ---
 

--- a/userspace/src/bin/udp.rs
+++ b/userspace/src/bin/udp.rs
@@ -10,12 +10,9 @@ const DELETE: u8 = 127;
 
 fn main() {
     println!("Hello from the udp receiver");
-    println!("Listening on {PORT}");
 
     let socket = Arc::new(UdpSocket::bind(format!("0.0.0.0:{PORT}")).expect("bind must work"));
-    // Kernel recvfrom always returns EAGAIN when no data (blocking not implemented),
-    // so we must use non-blocking mode and poll.
-    socket.set_nonblocking(true).expect("nonblocking must work");
+    println!("Listening on {PORT}");
 
     let last_sender: Arc<Mutex<Option<SocketAddr>>> = Arc::new(Mutex::new(None));
 
@@ -31,7 +28,6 @@ fn main() {
                     print!("{}", text);
                     let _ = stdout().flush();
                 }
-                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
                 Err(e) => panic!("recv_from failed: {e}"),
             }
         }


### PR DESCRIPTION
## Summary

- **Interrupt-driven network RX**: VirtIO network device now generates PLIC interrupts on packet arrival, replacing polling-based approaches
- **InterruptGuard in Spinlock**: Every spinlock acquisition now disables/restores interrupts (spin_lock_irqsave pattern), preventing deadlocks between interrupt handlers and thread context
- **Kernel worker thread**: Async task polling moved from interrupt handlers to a dedicated kernel thread where interrupts are enabled, allowing the kernel to remain responsive during packet processing
- **UDP system test fixes**: Resolved multiple race conditions in the UDP network path

## Test plan

- [x] `just clippy` passes with no warnings
- [x] All 138 unit tests pass
- [x] All 29 system tests pass, including the `udp` network test that exercises the full interrupt -> waker -> worker thread -> packet processing path
- [x] `stress_thread` and `stress_process` stress tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)