### PR TITLE
feat: DHCP client and UDP signal/socket fixes

### DIFF
--- a/common/src/ioctl.rs
+++ b/common/src/ioctl.rs
@@ -1,6 +1,17 @@
 pub const SOLAYA_PANIC: u32 = 0x5301;
 pub const SOLAYA_LIST_PROGRAMS: u32 = 0x5302;
 
+pub const SIOCGIFHWADDR: u32 = 0x8927;
+pub const SIOCSIFADDR: u32 = 0x8916;
+pub const ARPHRD_ETHER: u16 = 1;
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct Ifreq {
+    pub ifr_name: [u8; 16],
+    pub ifr_data: [u8; 16],
+}
+
 #[cfg(target_arch = "riscv64")]
 const NR_IOCTL: usize = 29;
 
@@ -26,4 +37,54 @@ pub fn print_programs() {
             in("a7") NR_IOCTL,
         );
     }
+}
+
+#[cfg(target_arch = "riscv64")]
+pub fn get_mac_address(socket_fd: i32) -> Option<[u8; 6]> {
+    let mut ifreq = Ifreq {
+        ifr_name: [0; 16],
+        ifr_data: [0; 16],
+    };
+    let ret: isize;
+    unsafe {
+        core::arch::asm!(
+            "ecall",
+            inlateout("a0") socket_fd as usize => ret,
+            in("a1") SIOCGIFHWADDR as usize,
+            in("a2") &mut ifreq as *mut Ifreq as usize,
+            in("a7") NR_IOCTL,
+        );
+    }
+    if ret != 0 {
+        return None;
+    }
+    // MAC is at ifr_data[2..8] (after sa_family u16)
+    let mut mac = [0u8; 6];
+    mac.copy_from_slice(&ifreq.ifr_data[2..8]);
+    Some(mac)
+}
+
+#[cfg(target_arch = "riscv64")]
+pub fn set_ip_address(socket_fd: i32, ip: [u8; 4]) {
+    let mut ifreq = Ifreq {
+        ifr_name: [0; 16],
+        ifr_data: [0; 16],
+    };
+    // sockaddr_in: sa_family=AF_INET(2) as u16 LE, then sin_port(2 bytes), then sin_addr(4 bytes)
+    ifreq.ifr_data[0] = 2; // AF_INET low byte
+    ifreq.ifr_data[1] = 0; // AF_INET high byte
+    // sin_port = 0 (bytes 2-3)
+    // sin_addr at bytes 4-7
+    ifreq.ifr_data[4..8].copy_from_slice(&ip);
+    let ret: isize;
+    unsafe {
+        core::arch::asm!(
+            "ecall",
+            inlateout("a0") socket_fd as usize => ret,
+            in("a1") SIOCSIFADDR as usize,
+            in("a2") &mut ifreq as *mut Ifreq as usize,
+            in("a7") NR_IOCTL,
+        );
+    }
+    assert!(ret == 0, "ioctl SIOCSIFADDR failed");
 }

--- a/doc/ai/NETWORKING.md
+++ b/doc/ai/NETWORKING.md
@@ -240,11 +240,11 @@ match socket.recv_from(&mut buf) {
 
 ## DHCP
 
-**File:** `userspace/src/bin/dhcp.rs`
+**File:** `userspace/src/bin/dhcpd.rs`
 
 The DHCP client runs as a userspace program during boot (spawned by `init` before the shell). It gets the NIC MAC via `ioctl(SIOCGIFHWADDR)`, performs the standard 4-step DHCP handshake (DISCOVER, OFFER, REQUEST, ACK), then configures the kernel IP via `ioctl(SIOCSIFADDR)`.
 
-Prints `dhcp: configured ip X.X.X.X` on success. Exits cleanly with status 1 if no network device is present (boot continues regardless).
+Prints `dhcpd: configured ip X.X.X.X` on success. Exits cleanly with status 1 if no network device is present (boot continues regardless).
 
 With QEMU user-mode networking, the built-in DHCP server assigns `10.0.2.15`.
 
@@ -268,5 +268,5 @@ Default configuration (via qemu_wrapper.sh):
 | kernel/src/net/udp.rs | UDP handling |
 | kernel/src/net/mac.rs | MAC address type |
 | kernel/src/drivers/virtio/net/ | VirtIO network device |
-| userspace/src/bin/dhcp.rs | DHCP client |
+| userspace/src/bin/dhcpd.rs | DHCP client |
 | common/src/ioctl.rs | Network ioctl wrappers (MAC, IP) |

--- a/doc/ai/NETWORKING.md
+++ b/doc/ai/NETWORKING.md
@@ -7,6 +7,7 @@ Network stack implementing:
 - ARP (Address Resolution Protocol)
 - IPv4 packet handling
 - UDP sockets
+- DHCP client (dynamic IP configuration)
 
 Currently UDP only - no TCP support.
 
@@ -44,10 +45,12 @@ Currently UDP only - no TCP support.
 
 ```rust
 static NETWORK_DEVICE: Spinlock<Option<NetworkDevice>> = Spinlock::new(None);
-static IP_ADDR: Ipv4Addr = Ipv4Addr::new(10, 0, 2, 15);  // QEMU default
+static IP_ADDR: Spinlock<Ipv4Addr> = Spinlock::new(Ipv4Addr::new(0, 0, 0, 0)); // Set by DHCP
 pub static ARP_CACHE: Spinlock<BTreeMap<Ipv4Addr, MacAddress>> = Spinlock::new(BTreeMap::new());
 pub static OPEN_UDP_SOCKETS: Spinlock<LazyCell<OpenSockets>> = ...;
 ```
+
+IP address starts as `0.0.0.0` and is configured dynamically by the DHCP client at boot.
 
 ## Packet Reception Flow
 
@@ -66,13 +69,10 @@ fn process_packet(packet: Vec<u8>) {
         EtherTypes::Arp => arp::process_and_respond(rest),
         EtherTypes::IPv4 => {
             let (ipv4_header, rest) = IpV4Header::process(rest)?;
+            // Opportunistically cache source MAC from Ethernet header
+            arp::cache_insert(ipv4_header.source_ip, ethernet_header.source_mac());
             let (udp_header, data) = UdpHeader::process(rest, ipv4_header)?;
-            OPEN_UDP_SOCKETS.lock().put_data(
-                ipv4_header.source_ip,
-                udp_header.source_port(),
-                udp_header.destination_port(),
-                data,
-            );
+            OPEN_UDP_SOCKETS.lock().put_data(...);
         }
     }
 }
@@ -148,6 +148,7 @@ pub enum EtherTypes {
 Handles ARP requests/responses:
 - Responds to ARP requests for our IP
 - Caches sender's MAC in ARP_CACHE
+- MAC addresses are also learned opportunistically from incoming IPv4 packets' Ethernet headers via `cache_insert()`
 
 ### IPv4
 
@@ -161,7 +162,7 @@ pub struct IpV4Header {
 }
 ```
 
-Currently only processes UDP protocol (17).
+Currently only processes UDP protocol (17). Accepts packets destined for our IP, broadcast (`255.255.255.255`), or any IP when our address is `0.0.0.0` (pre-DHCP).
 
 ### UDP
 
@@ -205,13 +206,19 @@ Creates an unbound UDP socket fd. `SOCK_CLOEXEC` flag is masked out (no exec to 
 Binds the socket to a port. Acquires a socket from the global socket table.
 
 ### sendto(fd, buf, len, flags, dest_addr, addrlen)
-Sends a UDP packet. Looks up destination MAC via ARP cache, constructs the full UDP/IP/Ethernet packet, and sends via VirtIO.
+Sends a UDP packet. Returns `ENETDOWN` if no network device. For broadcast destination (`255.255.255.255`), uses broadcast MAC `ff:ff:ff:ff:ff:ff`. Otherwise looks up destination MAC via ARP cache. Constructs the full UDP/IP/Ethernet packet and sends via VirtIO.
 
 ### recvfrom(fd, buf, len, flags, src_addr, addrlen)
 Calls `receive_and_process_packets()` to poll the NIC, then pops the first datagram from the socket's queue. Returns sender address in `src_addr`. Returns `EAGAIN` if no data and `O_NONBLOCK` is set.
 
 ### ioctl(fd, FIONBIO, &value)
 Sets/clears `O_NONBLOCK` on a socket fd. Used by `std::net::UdpSocket::set_nonblocking()`.
+
+### ioctl(fd, SIOCGIFHWADDR, &ifreq)
+Returns the NIC's MAC address in `ifreq.ifr_data` as `sockaddr` with `sa_family = ARPHRD_ETHER(1)` and MAC in `sa_data[0..6]`. Returns `ENODEV` if no network device.
+
+### ioctl(fd, SIOCSIFADDR, &ifreq)
+Sets the kernel's IP address from `sockaddr_in` in `ifreq.ifr_data`. Used by the DHCP client after receiving an address.
 
 ## Userspace Example
 
@@ -230,6 +237,16 @@ match socket.recv_from(&mut buf) {
     Err(e) => panic!("{e}"),
 }
 ```
+
+## DHCP
+
+**File:** `userspace/src/bin/dhcp.rs`
+
+The DHCP client runs as a userspace program during boot (spawned by `init` before the shell). It gets the NIC MAC via `ioctl(SIOCGIFHWADDR)`, performs the standard 4-step DHCP handshake (DISCOVER, OFFER, REQUEST, ACK), then configures the kernel IP via `ioctl(SIOCSIFADDR)`.
+
+Prints `dhcp: configured ip X.X.X.X` on success. Exits cleanly with status 1 if no network device is present (boot continues regardless).
+
+With QEMU user-mode networking, the built-in DHCP server assigns `10.0.2.15`.
 
 ## QEMU Network Setup
 
@@ -251,3 +268,5 @@ Default configuration (via qemu_wrapper.sh):
 | kernel/src/net/udp.rs | UDP handling |
 | kernel/src/net/mac.rs | MAC address type |
 | kernel/src/drivers/virtio/net/ | VirtIO network device |
+| userspace/src/bin/dhcp.rs | DHCP client |
+| common/src/ioctl.rs | Network ioctl wrappers (MAC, IP) |

--- a/kernel/src/net/arp.rs
+++ b/kernel/src/net/arp.rs
@@ -21,6 +21,10 @@ pub fn cache_lookup(ip: &Ipv4Addr) -> Option<MacAddress> {
     ARP_CACHE.lock().get(ip).copied()
 }
 
+pub fn cache_insert(ip: Ipv4Addr, mac: MacAddress) {
+    ARP_CACHE.lock().insert(ip, mac);
+}
+
 const ARP_REQUEST: u16 = 1;
 const ARP_RESPONSE: u16 = 2;
 

--- a/kernel/src/net/ethernet.rs
+++ b/kernel/src/net/ethernet.rs
@@ -112,6 +112,10 @@ impl EthernetHeader {
     pub fn ether_type(&self) -> EtherTypes {
         EtherTypes::try_from(self.ether_type).expect("Must be already parsed.")
     }
+
+    pub fn source_mac(&self) -> MacAddress {
+        self.source_mac
+    }
 }
 
 impl Display for EthernetHeader {

--- a/kernel/src/net/ipv4.rs
+++ b/kernel/src/net/ipv4.rs
@@ -75,8 +75,11 @@ impl IpV4Header {
             "We don't support fragmented packets yet."
         );
 
+        let our_ip = super::ip_addr();
         assert!(
-            ipv4_header.destination_ip == super::ip_addr(),
+            ipv4_header.destination_ip == our_ip
+                || ipv4_header.destination_ip == Ipv4Addr::BROADCAST
+                || our_ip == Ipv4Addr::UNSPECIFIED,
             "Destination ip address is not ours."
         );
 

--- a/kernel/src/net/mac.rs
+++ b/kernel/src/net/mac.rs
@@ -8,6 +8,10 @@ impl MacAddress {
     pub const fn new(address: [u8; 6]) -> Self {
         Self(address)
     }
+
+    pub fn as_bytes(&self) -> [u8; 6] {
+        self.0
+    }
 }
 
 impl Display for MacAddress {

--- a/kernel/src/net/mod.rs
+++ b/kernel/src/net/mod.rs
@@ -27,13 +27,13 @@ pub mod udp;
 
 struct NetworkStack {
     device: Spinlock<Option<NetworkDevice>>,
-    ip_addr: Ipv4Addr,
+    ip_addr: Spinlock<Ipv4Addr>,
     open_sockets: Spinlock<LazyCell<OpenSockets>>,
 }
 
 static NETWORK_STACK: NetworkStack = NetworkStack {
     device: Spinlock::new(None),
-    ip_addr: Ipv4Addr::new(10, 0, 2, 15),
+    ip_addr: Spinlock::new(Ipv4Addr::new(0, 0, 0, 0)),
     open_sockets: Spinlock::new(LazyCell::new(OpenSockets::new)),
 };
 
@@ -102,7 +102,15 @@ pub async fn network_rx_task() {
 }
 
 pub fn ip_addr() -> Ipv4Addr {
-    NETWORK_STACK.ip_addr
+    *NETWORK_STACK.ip_addr.lock()
+}
+
+pub fn set_ip_addr(addr: Ipv4Addr) {
+    *NETWORK_STACK.ip_addr.lock() = addr;
+}
+
+pub fn has_network_device() -> bool {
+    NETWORK_STACK.device.lock().is_some()
 }
 
 pub fn open_sockets() -> &'static Spinlock<LazyCell<OpenSockets>> {
@@ -162,12 +170,13 @@ fn process_packet(packet: Vec<u8>) {
 
     match ether_type {
         ethernet::EtherTypes::Arp => arp::process_and_respond(rest),
-        ethernet::EtherTypes::IPv4 => process_ipv4_packet(rest),
+        ethernet::EtherTypes::IPv4 => process_ipv4_packet(rest, ethernet_header.source_mac()),
     }
 }
 
-fn process_ipv4_packet(data: &[u8]) {
+fn process_ipv4_packet(data: &[u8], source_mac: MacAddress) {
     let (ipv4_header, rest) = IpV4Header::process(data).expect("IPv4 packet must be processed.");
+    arp::cache_insert(ipv4_header.source_ip, source_mac);
     let (udp_header, data) =
         UdpHeader::process(rest, ipv4_header).expect("Udp header must be valid.");
     open_sockets().lock().put_data(

--- a/kernel/src/net/udp.rs
+++ b/kernel/src/net/udp.rs
@@ -113,17 +113,11 @@ impl UdpHeader {
         let data_length = udp_header.length.get() as usize - Self::UDP_HEADER_SIZE;
         let rest = &rest[..data_length];
 
-        // Check checksum
-        assert!(
-            udp_header.checksum.get() != 0,
-            "we test impl for checksum not zero"
-        );
-
-        debug!("Got checksum: {:#x}", udp_header.checksum.get());
-
-        let computed_checksum = Self::compute_checksum(rest, udp_header, ip_header);
-
-        assert_eq!(computed_checksum, 0, "must be zero for a valid packet.");
+        if udp_header.checksum.get() != 0 {
+            debug!("Got checksum: {:#x}", udp_header.checksum.get());
+            let computed_checksum = Self::compute_checksum(rest, udp_header, ip_header);
+            assert_eq!(computed_checksum, 0, "must be zero for a valid packet.");
+        }
 
         Ok((udp_header, rest))
     }

--- a/kernel/src/processes/process_table.rs
+++ b/kernel/src/processes/process_table.rs
@@ -237,6 +237,7 @@ impl ProcessTable {
             LIVE_THREAD_COUNT.fetch_sub(1, Ordering::Relaxed);
             let (main_tid, futex_addr) = thread.with_lock(|mut t| {
                 t.set_state(ThreadState::Zombie(exit_status));
+                t.take_syscall_task();
                 Cpu::current().ipi_to_all_but_me();
 
                 let futex_addr = if let Some(clear_child_tid) = t.get_clear_child_tid() {

--- a/kernel/src/processes/scheduler.rs
+++ b/kernel/src/processes/scheduler.rs
@@ -113,7 +113,30 @@ impl CpuScheduler {
             }
             true
         } else {
-            // Still pending — store the task back and keep the thread waiting.
+            // Still pending — check if a terminating signal arrived while we
+            // were blocked. We intentionally avoid deliver_signal() here because
+            // it may set up a handler frame (modifying PC/SP), which would
+            // corrupt state if we then stored the task back.
+            let exit_status = self.current_thread.with_lock(|mut t| {
+                let sig = t.peek_first_unblocked_signal()?;
+                let action = t.get_sigaction_raw(sig);
+                if action.sa_handler.is_none()
+                    && matches!(
+                        super::signal::default_action(sig),
+                        super::signal::DefaultAction::Terminate
+                    )
+                {
+                    t.take_next_pending_signal();
+                    return Some(super::signal::ExitStatus::Signaled(
+                        u8::try_from(sig).expect("signal number fits in u8"),
+                    ));
+                }
+                None
+            });
+            if let Some(exit_status) = exit_status {
+                self.kill_current_process(exit_status);
+                return false;
+            }
             self.current_thread
                 .lock()
                 .set_syscall_task_and_suspend(task);

--- a/kernel/src/processes/thread.rs
+++ b/kernel/src/processes/thread.rs
@@ -513,6 +513,12 @@ impl Thread {
             .is_some()
     }
 
+    pub fn peek_first_unblocked_signal(&self) -> Option<u32> {
+        self.signal_state
+            .pending
+            .first_unblocked(self.signal_state.sigmask.sig[0])
+    }
+
     pub fn take_next_pending_signal(&mut self) -> Option<u32> {
         let sig = self
             .signal_state

--- a/kernel/src/syscalls/linux.rs
+++ b/kernel/src/syscalls/linux.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 use alloc::{string::String, sync::Arc, vec::Vec};
 use common::{
-    ioctl::{SOLAYA_LIST_PROGRAMS, SOLAYA_PANIC},
+    ioctl::{ARPHRD_ETHER, Ifreq, SIOCGIFHWADDR, SIOCSIFADDR, SOLAYA_LIST_PROGRAMS, SOLAYA_PANIC},
     pid::Tid,
     syscalls::trap_frame::{Register, TrapFrame},
 };
@@ -495,6 +495,39 @@ impl LinuxSyscalls for LinuxSyscallHandler {
                     .with_lock(|p| p.fd_table().set_flags(fd, flags))?;
                 Ok(0)
             }
+            FileDescriptor::UdpSocket(_) | FileDescriptor::UnboundUdpSocket
+                if op == SIOCGIFHWADDR =>
+            {
+                if !net::has_network_device() {
+                    return Err(Errno::ENODEV);
+                }
+                let ifreq_ptr = LinuxUserspaceArg::<*mut Ifreq>::new(arg, self.get_process());
+                let mac = net::current_mac_address();
+                let mut result = Ifreq {
+                    ifr_name: [0; 16],
+                    ifr_data: [0; 16],
+                };
+                let [lo, hi] = ARPHRD_ETHER.to_le_bytes();
+                result.ifr_data[0] = lo;
+                result.ifr_data[1] = hi;
+                result.ifr_data[2..8].copy_from_slice(&mac.as_bytes());
+                ifreq_ptr.write_slice(&[result])?;
+                Ok(0)
+            }
+            FileDescriptor::UdpSocket(_) | FileDescriptor::UnboundUdpSocket
+                if op == SIOCSIFADDR =>
+            {
+                let ifreq_ptr = LinuxUserspaceArg::<*const Ifreq>::new(arg, self.get_process());
+                let ifreq = ifreq_ptr.validate_ptr()?;
+                let ip = core::net::Ipv4Addr::new(
+                    ifreq.ifr_data[4],
+                    ifreq.ifr_data[5],
+                    ifreq.ifr_data[6],
+                    ifreq.ifr_data[7],
+                );
+                net::set_ip_addr(ip);
+                Ok(0)
+            }
             _ => Err(Errno::EINVAL),
         }
     }
@@ -813,8 +846,15 @@ impl LinuxSyscalls for LinuxSyscallHandler {
         let dest_ip = core::net::Ipv4Addr::from(u32::from_be(sin.sin_addr.s_addr));
         let dest_port = u16::from_be(sin.sin_port);
 
-        let destination_mac =
-            arp::cache_lookup(&dest_ip).expect("sendto: destination MAC must be in ARP cache");
+        if !net::has_network_device() {
+            return Err(Errno::ENETDOWN);
+        }
+
+        let destination_mac = if dest_ip == core::net::Ipv4Addr::BROADCAST {
+            net::mac::MacAddress::new([0xff, 0xff, 0xff, 0xff, 0xff, 0xff])
+        } else {
+            arp::cache_lookup(&dest_ip).expect("sendto: destination MAC must be in ARP cache")
+        };
 
         let source_port = socket.lock().get_port().as_u16();
         let packet =

--- a/kernel/src/syscalls/linux.rs
+++ b/kernel/src/syscalls/linux.rs
@@ -796,6 +796,10 @@ impl LinuxSyscalls for LinuxSyscallHandler {
             "bind: fd {fd} is not an unbound UDP socket"
         );
 
+        if !net::has_network_device() {
+            return Err(Errno::ENETDOWN);
+        }
+
         let sin_arg =
             LinuxUserspaceArg::<*const sockaddr_in>::new(addr.raw_arg(), self.get_process());
         let sin = sin_arg.validate_ptr()?;

--- a/qemu-infra/src/qemu.rs
+++ b/qemu-infra/src/qemu.rs
@@ -131,7 +131,7 @@ impl QemuInstance {
         stdout.assert_read_until("kernel_init done!").await?;
         stdout.assert_read_until("init process started").await?;
         if network_port.is_some() {
-            stdout.assert_read_until("dhcp: configured ip").await?;
+            stdout.assert_read_until("dhcpd: configured ip").await?;
         }
         stdout
             .assert_read_until("### SoSH - Solaya Shell ###")

--- a/qemu-infra/src/qemu.rs
+++ b/qemu-infra/src/qemu.rs
@@ -130,6 +130,9 @@ impl QemuInstance {
         stdout.assert_read_until("Hello World from Solaya!").await?;
         stdout.assert_read_until("kernel_init done!").await?;
         stdout.assert_read_until("init process started").await?;
+        if network_port.is_some() {
+            stdout.assert_read_until("dhcp: configured ip").await?;
+        }
         stdout
             .assert_read_until("### SoSH - Solaya Shell ###")
             .await?;

--- a/system-tests/src/tests/net.rs
+++ b/system-tests/src/tests/net.rs
@@ -4,7 +4,7 @@ use crate::infra::qemu::{QemuInstance, QemuOptions};
 
 #[tokio::test]
 async fn dhcp() -> anyhow::Result<()> {
-    // start_with asserts "dhcp: configured ip" when network is enabled
+    // start_with asserts "dhcpd: configured ip" when network is enabled
     let _solaya = QemuInstance::start_with(QemuOptions::default().add_network_card(true)).await?;
     Ok(())
 }

--- a/system-tests/src/tests/net.rs
+++ b/system-tests/src/tests/net.rs
@@ -3,6 +3,13 @@ use tokio::io::AsyncWriteExt;
 use crate::infra::qemu::{QemuInstance, QemuOptions};
 
 #[tokio::test]
+async fn dhcp() -> anyhow::Result<()> {
+    // start_with asserts "dhcp: configured ip" when network is enabled
+    let _solaya = QemuInstance::start_with(QemuOptions::default().add_network_card(true)).await?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn udp() -> anyhow::Result<()> {
     let mut solaya =
         QemuInstance::start_with(QemuOptions::default().add_network_card(true)).await?;

--- a/todo/overview.md
+++ b/todo/overview.md
@@ -11,7 +11,7 @@ This document contains research summaries for planned future enhancements. Each 
 5. [QEMU Framebuffer](#5-qemu-framebuffer)
 6. [Port Doom](#6-port-doom)
 7. [Async Network Reception with Interrupts](#7-async-network-reception-with-interrupts)
-8. [DHCP Client](#8-dhcp-client)
+8. [~~DHCP Client~~](#8-dhcp-client) (Implemented)
 9. [Minimal TCP Implementation](#9-minimal-tcp-implementation)
 10. [Dynamic Linking](#10-dynamic-linking)
 11. [QEMU Random Device Driver](#11-qemu-random-device-driver)
@@ -935,7 +935,7 @@ If cross-compilation proves difficult:
 6. **#4 - Coreutils** (User-facing utilities)
 
 ### Phase 3: Networking Enhancements
-7. **#8 - DHCP Client** (Network configuration)
+7. ~~**#8 - DHCP Client**~~ (Implemented)
 8. **#9 - Minimal TCP** (Protocol expansion)
 
 ### Phase 4: Advanced Features

--- a/todo/overview.md
+++ b/todo/overview.md
@@ -480,7 +480,7 @@ impl Future for RecvWait {
 
 ### Minimal Viable Implementation
 
-**Userspace client** (`userspace/src/bin/dhcp.rs`):
+**Userspace client** (`userspace/src/bin/dhcpd.rs`):
 ```rust
 fn main() {
     let socket = UdpSocket::bind("0.0.0.0:68")?;

--- a/userspace/src/bin/dhcp.rs
+++ b/userspace/src/bin/dhcp.rs
@@ -1,0 +1,196 @@
+use std::{net::UdpSocket, os::fd::AsRawFd};
+
+use common::ioctl::{get_mac_address, set_ip_address};
+
+const DHCP_SERVER_PORT: u16 = 67;
+const DHCP_CLIENT_PORT: u16 = 68;
+
+const BOOTREQUEST: u8 = 1;
+const BOOTREPLY: u8 = 2;
+const HTYPE_ETHERNET: u8 = 1;
+const HLEN_ETHERNET: u8 = 6;
+
+const DHCP_MAGIC_COOKIE: [u8; 4] = [99, 130, 83, 99];
+
+const OPT_SUBNET_MASK: u8 = 1;
+const OPT_ROUTER: u8 = 3;
+const OPT_MESSAGE_TYPE: u8 = 53;
+const OPT_SERVER_ID: u8 = 54;
+const OPT_REQUESTED_IP: u8 = 50;
+const OPT_PARAM_REQUEST: u8 = 55;
+const OPT_END: u8 = 255;
+
+const DHCPDISCOVER: u8 = 1;
+const DHCPOFFER: u8 = 2;
+const DHCPREQUEST: u8 = 3;
+const DHCPACK: u8 = 5;
+
+const DHCP_HEADER_SIZE: usize = 236;
+
+fn build_discover(mac: &[u8; 6], xid: u32) -> Vec<u8> {
+    let mut pkt = vec![0u8; DHCP_HEADER_SIZE];
+    pkt[0] = BOOTREQUEST;
+    pkt[1] = HTYPE_ETHERNET;
+    pkt[2] = HLEN_ETHERNET;
+    // hops = 0
+    pkt[4..8].copy_from_slice(&xid.to_be_bytes());
+    // flags: broadcast
+    pkt[10] = 0x80;
+    // chaddr
+    pkt[28..34].copy_from_slice(mac);
+
+    // Options
+    pkt.extend_from_slice(&DHCP_MAGIC_COOKIE);
+    // Message type = DISCOVER
+    pkt.extend_from_slice(&[OPT_MESSAGE_TYPE, 1, DHCPDISCOVER]);
+    // Parameter request list
+    pkt.extend_from_slice(&[OPT_PARAM_REQUEST, 2, OPT_SUBNET_MASK, OPT_ROUTER]);
+    // End
+    pkt.push(OPT_END);
+
+    pkt
+}
+
+fn build_request(mac: &[u8; 6], xid: u32, offered_ip: [u8; 4], server_id: [u8; 4]) -> Vec<u8> {
+    let mut pkt = vec![0u8; DHCP_HEADER_SIZE];
+    pkt[0] = BOOTREQUEST;
+    pkt[1] = HTYPE_ETHERNET;
+    pkt[2] = HLEN_ETHERNET;
+    pkt[4..8].copy_from_slice(&xid.to_be_bytes());
+    // flags: broadcast
+    pkt[10] = 0x80;
+    // chaddr
+    pkt[28..34].copy_from_slice(mac);
+
+    // Options
+    pkt.extend_from_slice(&DHCP_MAGIC_COOKIE);
+    // Message type = REQUEST
+    pkt.extend_from_slice(&[OPT_MESSAGE_TYPE, 1, DHCPREQUEST]);
+    // Requested IP
+    pkt.extend_from_slice(&[OPT_REQUESTED_IP, 4]);
+    pkt.extend_from_slice(&offered_ip);
+    // Server ID
+    pkt.extend_from_slice(&[OPT_SERVER_ID, 4]);
+    pkt.extend_from_slice(&server_id);
+    // End
+    pkt.push(OPT_END);
+
+    pkt
+}
+
+struct DhcpResponse {
+    msg_type: u8,
+    yiaddr: [u8; 4],
+    server_id: [u8; 4],
+}
+
+fn parse_response(data: &[u8], expected_xid: u32) -> Option<DhcpResponse> {
+    if data.len() < DHCP_HEADER_SIZE + 4 {
+        return None;
+    }
+    if data[0] != BOOTREPLY {
+        return None;
+    }
+    let xid = u32::from_be_bytes([data[4], data[5], data[6], data[7]]);
+    if xid != expected_xid {
+        return None;
+    }
+
+    let mut yiaddr = [0u8; 4];
+    yiaddr.copy_from_slice(&data[16..20]);
+
+    // Parse options after magic cookie
+    let opts_start = DHCP_HEADER_SIZE + 4;
+    if data[DHCP_HEADER_SIZE..opts_start] != DHCP_MAGIC_COOKIE {
+        return None;
+    }
+
+    let mut msg_type = 0u8;
+    let mut server_id = [0u8; 4];
+    let mut i = opts_start;
+    while i < data.len() {
+        let opt = data[i];
+        if opt == OPT_END {
+            break;
+        }
+        if opt == 0 {
+            // Padding
+            i += 1;
+            continue;
+        }
+        if i + 1 >= data.len() {
+            break;
+        }
+        let len = data[i + 1] as usize;
+        let val_start = i + 2;
+        if val_start + len > data.len() {
+            break;
+        }
+        match opt {
+            OPT_MESSAGE_TYPE if len == 1 => msg_type = data[val_start],
+            OPT_SERVER_ID if len == 4 => {
+                server_id.copy_from_slice(&data[val_start..val_start + 4]);
+            }
+            _ => {}
+        }
+        i = val_start + len;
+    }
+
+    Some(DhcpResponse {
+        msg_type,
+        yiaddr,
+        server_id,
+    })
+}
+
+fn main() {
+    let socket = match UdpSocket::bind(format!("0.0.0.0:{DHCP_CLIENT_PORT}")) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("dhcp: bind failed: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let mac = match get_mac_address(socket.as_raw_fd()) {
+        Some(m) => m,
+        None => {
+            eprintln!("dhcp: no network device");
+            std::process::exit(1);
+        }
+    };
+    let xid: u32 = 0x12345678;
+
+    // Send DISCOVER
+    let discover = build_discover(&mac, xid);
+    if let Err(e) = socket.send_to(&discover, format!("255.255.255.255:{DHCP_SERVER_PORT}")) {
+        eprintln!("dhcp: send failed: {e}");
+        std::process::exit(1);
+    }
+
+    // Receive OFFER
+    let mut buf = [0u8; 1024];
+    let (n, _) = socket.recv_from(&mut buf).expect("dhcp: recv offer failed");
+    let offer = parse_response(&buf[..n], xid).expect("dhcp: invalid offer");
+    assert!(offer.msg_type == DHCPOFFER, "dhcp: expected OFFER");
+
+    // Send REQUEST
+    let request = build_request(&mac, xid, offer.yiaddr, offer.server_id);
+    socket
+        .send_to(&request, format!("255.255.255.255:{DHCP_SERVER_PORT}"))
+        .expect("dhcp: send request failed");
+
+    // Receive ACK
+    let (n, _) = socket.recv_from(&mut buf).expect("dhcp: recv ack failed");
+    let ack = parse_response(&buf[..n], xid).expect("dhcp: invalid ack");
+    assert!(ack.msg_type == DHCPACK, "dhcp: expected ACK");
+
+    // Configure IP
+    set_ip_address(socket.as_raw_fd(), ack.yiaddr);
+
+    let ip = ack.yiaddr;
+    println!(
+        "dhcp: configured ip {}.{}.{}.{}",
+        ip[0], ip[1], ip[2], ip[3]
+    );
+}

--- a/userspace/src/bin/dhcpd.rs
+++ b/userspace/src/bin/dhcpd.rs
@@ -147,7 +147,7 @@ fn main() {
     let socket = match UdpSocket::bind(format!("0.0.0.0:{DHCP_CLIENT_PORT}")) {
         Ok(s) => s,
         Err(e) => {
-            eprintln!("dhcp: bind failed: {e}");
+            eprintln!("dhcpd: bind failed: {e}");
             std::process::exit(1);
         }
     };
@@ -155,7 +155,7 @@ fn main() {
     let mac = match get_mac_address(socket.as_raw_fd()) {
         Some(m) => m,
         None => {
-            eprintln!("dhcp: no network device");
+            eprintln!("dhcpd: no network device");
             std::process::exit(1);
         }
     };
@@ -164,33 +164,35 @@ fn main() {
     // Send DISCOVER
     let discover = build_discover(&mac, xid);
     if let Err(e) = socket.send_to(&discover, format!("255.255.255.255:{DHCP_SERVER_PORT}")) {
-        eprintln!("dhcp: send failed: {e}");
+        eprintln!("dhcpd: send failed: {e}");
         std::process::exit(1);
     }
 
     // Receive OFFER
     let mut buf = [0u8; 1024];
-    let (n, _) = socket.recv_from(&mut buf).expect("dhcp: recv offer failed");
-    let offer = parse_response(&buf[..n], xid).expect("dhcp: invalid offer");
-    assert!(offer.msg_type == DHCPOFFER, "dhcp: expected OFFER");
+    let (n, _) = socket
+        .recv_from(&mut buf)
+        .expect("dhcpd: recv offer failed");
+    let offer = parse_response(&buf[..n], xid).expect("dhcpd: invalid offer");
+    assert!(offer.msg_type == DHCPOFFER, "dhcpd: expected OFFER");
 
     // Send REQUEST
     let request = build_request(&mac, xid, offer.yiaddr, offer.server_id);
     socket
         .send_to(&request, format!("255.255.255.255:{DHCP_SERVER_PORT}"))
-        .expect("dhcp: send request failed");
+        .expect("dhcpd: send request failed");
 
     // Receive ACK
-    let (n, _) = socket.recv_from(&mut buf).expect("dhcp: recv ack failed");
-    let ack = parse_response(&buf[..n], xid).expect("dhcp: invalid ack");
-    assert!(ack.msg_type == DHCPACK, "dhcp: expected ACK");
+    let (n, _) = socket.recv_from(&mut buf).expect("dhcpd: recv ack failed");
+    let ack = parse_response(&buf[..n], xid).expect("dhcpd: invalid ack");
+    assert!(ack.msg_type == DHCPACK, "dhcpd: expected ACK");
 
     // Configure IP
     set_ip_address(socket.as_raw_fd(), ack.yiaddr);
 
     let ip = ack.yiaddr;
     println!(
-        "dhcp: configured ip {}.{}.{}.{}",
+        "dhcpd: configured ip {}.{}.{}.{}",
         ip[0], ip[1], ip[2], ip[3]
     );
 }

--- a/userspace/src/bin/init.rs
+++ b/userspace/src/bin/init.rs
@@ -2,6 +2,9 @@ use userspace::spawn::spawn;
 
 fn main() {
     println!("init process started");
+    if let Ok(mut child) = spawn("dhcp", &[]) {
+        let _ = child.wait();
+    }
     println!("starting shell");
     let mut child = spawn("sosh", &[]).expect("Failed to spawn shell");
     child.wait().expect("Failed to wait for shell");

--- a/userspace/src/bin/init.rs
+++ b/userspace/src/bin/init.rs
@@ -2,7 +2,7 @@ use userspace::spawn::spawn;
 
 fn main() {
     println!("init process started");
-    if let Ok(mut child) = spawn("dhcp", &[]) {
+    if let Ok(mut child) = spawn("dhcpd", &[]) {
         let _ = child.wait();
     }
     println!("starting shell");


### PR DESCRIPTION
## Summary
- Implement DHCP client (`dhcpd`) that runs at boot to dynamically configure the kernel IP via the standard 4-step handshake (DISCOVER, OFFER, REQUEST, ACK)
- Fix Ctrl+C not killing processes blocked in async syscalls (e.g. `recvfrom`) by checking for terminating signals after poll returns Pending
- Fix socket port leak on process kill by dropping `SyscallTask` in `kill()`, allowing port reuse
- Return `ENETDOWN` from `bind()` when no network device exists instead of silently blocking

## Test plan
- [x] `tests::net::dhcp` — verifies DHCP configures IP on boot with network enabled
- [x] `tests::signals::should_exit_program` — Ctrl+C kills `udp` process
- [x] `tests::signals::should_rerun_udp_after_ctrl_c` — port reuse after kill
- [x] All 33 system tests pass
- [x] All 138 unit tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)