### PR TITLE
Replace raw ecalls with extern C ioctl declarations

### DIFF
--- a/common/src/ioctl.rs
+++ b/common/src/ioctl.rs
@@ -13,29 +13,21 @@ pub struct Ifreq {
 }
 
 #[cfg(target_arch = "riscv64")]
-const NR_IOCTL: usize = 29;
+unsafe extern "C" {
+    fn ioctl(fd: i32, request: u32, ...) -> i32;
+}
 
 #[cfg(target_arch = "riscv64")]
 pub fn trigger_kernel_panic() {
     unsafe {
-        core::arch::asm!(
-            "ecall",
-            inlateout("a0") 1usize => _,
-            in("a1") SOLAYA_PANIC as usize,
-            in("a7") NR_IOCTL,
-        );
+        ioctl(1, SOLAYA_PANIC);
     }
 }
 
 #[cfg(target_arch = "riscv64")]
 pub fn print_programs() {
     unsafe {
-        core::arch::asm!(
-            "ecall",
-            inlateout("a0") 1usize => _,
-            in("a1") SOLAYA_LIST_PROGRAMS as usize,
-            in("a7") NR_IOCTL,
-        );
+        ioctl(1, SOLAYA_LIST_PROGRAMS);
     }
 }
 
@@ -45,16 +37,7 @@ pub fn get_mac_address(socket_fd: i32) -> Option<[u8; 6]> {
         ifr_name: [0; 16],
         ifr_data: [0; 16],
     };
-    let ret: isize;
-    unsafe {
-        core::arch::asm!(
-            "ecall",
-            inlateout("a0") socket_fd as usize => ret,
-            in("a1") SIOCGIFHWADDR as usize,
-            in("a2") &mut ifreq as *mut Ifreq as usize,
-            in("a7") NR_IOCTL,
-        );
-    }
+    let ret = unsafe { ioctl(socket_fd, SIOCGIFHWADDR, &mut ifreq as *mut Ifreq) };
     if ret != 0 {
         return None;
     }
@@ -76,15 +59,6 @@ pub fn set_ip_address(socket_fd: i32, ip: [u8; 4]) {
     // sin_port = 0 (bytes 2-3)
     // sin_addr at bytes 4-7
     ifreq.ifr_data[4..8].copy_from_slice(&ip);
-    let ret: isize;
-    unsafe {
-        core::arch::asm!(
-            "ecall",
-            inlateout("a0") socket_fd as usize => ret,
-            in("a1") SIOCSIFADDR as usize,
-            in("a2") &mut ifreq as *mut Ifreq as usize,
-            in("a7") NR_IOCTL,
-        );
-    }
+    let ret = unsafe { ioctl(socket_fd, SIOCSIFADDR, &mut ifreq as *mut Ifreq) };
     assert!(ret == 0, "ioctl SIOCSIFADDR failed");
 }


### PR DESCRIPTION
## Summary

This PR refactors userspace ioctl wrapper functions to use proper `extern "C"` declarations instead of raw inline assembly `ecall` instructions.

**Main Changes:**
- Replaced inline assembly ecalls in `common/src/ioctl.rs` with `extern "C" { fn ioctl(...) }` linking to musl libc
- Removed the `NR_IOCTL` constant (syscall number 29) as it's no longer needed
- Fixed return type from `isize` to `i32` to match standard C ioctl

## Benefits

- Cleaner, more maintainable code
- Better alignment with standard C library conventions
- No raw assembly in userspace code
- Preserves all existing functionality

## Test plan

- [x] Clippy passes with no warnings
- [x] All unit tests pass (138 tests)
- [x] All system tests pass (33 tests)
- [x] Panic test verifies custom Solaya ioctl operations work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)