### PR TITLE
feat: add devfs with /dev/null and /dev/zero; refactor static directories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ doc/ai/           # Detailed AI documentation (see OVERVIEW.md)
 | kernel/src/processes/ | Process, thread, scheduler, signals |
 | kernel/src/syscalls/ | syscall handlers |
 | kernel/src/interrupts/ | Trap handling, PLIC, timer |
-| kernel/src/fs/ | VFS layer (tmpfs, procfs) |
+| kernel/src/fs/ | VFS layer (tmpfs, procfs, devfs) |
 | kernel/src/net/ | UDP network stack |
 | kernel/src/drivers/virtio/ | VirtIO network driver |
 | kernel/src/io/ | UART, stdin buffer |

--- a/doc/ai/FS.md
+++ b/doc/ai/FS.md
@@ -1,0 +1,93 @@
+# Filesystem (VFS)
+
+## Overview
+
+The VFS layer lives in `kernel/src/fs/`. All filesystems implement the `VfsNode` trait and are mounted into a global mount table. There is no block device layer — all filesystems are in-memory.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `vfs.rs` | `VfsNode` trait, mount table, path resolution, `StaticDir`, `RootDir` |
+| `tmpfs.rs` | Read-write in-memory filesystem (`TmpfsDir`, `TmpfsFile`) |
+| `procfs.rs` | `/proc` — `ProcVersionFile`, builder via `StaticDir` |
+| `devfs.rs` | `/dev` — `DevNull`, `DevZero`, builder via `StaticDir` |
+| `open_file.rs` | `VfsOpenFile` — per-fd state (offset, flags), read/write/seek |
+| `mod.rs` | `init()` — mounts `/`, `/tmp`, `/proc`, `/dev` |
+
+## Mount Layout
+
+```
+/         RootDir (virtual — lists mount points as children)
+/tmp      TmpfsDir (read-write, supports create/unlink)
+/proc     StaticDir { "version" -> ProcVersionFile }
+/dev      StaticDir { "null" -> DevNull, "zero" -> DevZero }
+```
+
+## VfsNode Trait
+
+Every node implements `node_type()`, `ino()`, and `size()`. Other methods have default implementations that return appropriate errors:
+
+- **Files** override: `read`, `write`, `truncate`
+- **Directories** override: `lookup`, `readdir`, and optionally `create`/`unlink` (only tmpfs supports mutation)
+
+Default errors: files return `ENOTDIR` for directory ops, directories return `EISDIR` for file ops.
+
+## Key Types
+
+- `VfsNodeRef` = `Arc<dyn VfsNode>` — shared reference-counted node
+- `VfsOpenFile` = `Arc<Spinlock<VfsOpenFileInner>>` — per-fd open file with offset tracking
+- `DirEntry` — returned by `readdir()`, contains name, ino, node_type
+- `NodeType` — enum: `File` or `Directory`
+
+## Inode Allocation
+
+`alloc_ino()` in `vfs.rs` uses a global `AtomicU64` counter. Every node gets a unique inode at construction time.
+
+## Path Resolution
+
+`resolve_path(path)` finds the longest-matching mount point, then walks remaining components via `lookup()`. `resolve_parent(path)` splits off the last component and resolves the parent directory. `resolve_relative(base, path)` walks from an existing node (used for dirfd-relative operations like `openat`).
+
+## StaticDir
+
+A reusable read-only directory for filesystems with fixed children (devfs, procfs). Constructed via `StaticDir::new(vec![("name", node), ...])`. Implements `lookup` and `readdir` over a `BTreeMap`.
+
+## Adding a New Filesystem Entry
+
+### New device in `/dev`
+Add entry to the vec in `devfs::new()`:
+```rust
+pub(super) fn new() -> Arc<StaticDir> {
+    StaticDir::new(vec![
+        ("null", Arc::new(DevNull { ino: alloc_ino() })),
+        ("zero", Arc::new(DevZero { ino: alloc_ino() })),
+        ("mydev", Arc::new(MyDev { ino: alloc_ino() })),  // new
+    ])
+}
+```
+
+### New file in `/proc`
+Same pattern in `procfs::new()`.
+
+### New mount point
+Add `vfs::mount("/path", node)` in `fs::init()`.
+
+## Related Syscalls
+
+Filesystem syscalls in `kernel/src/syscalls/linux.rs`:
+
+| Syscall | Purpose |
+|---------|---------|
+| `openat` | Open/create file, returns fd |
+| `close` | Close fd |
+| `read` / `write` / `writev` | File I/O |
+| `lseek` | Reposition file offset |
+| `fstat` / `fstatat` | Stat a file |
+| `getdents64` | Read directory entries |
+| `mkdirat` | Create directory (tmpfs only) |
+| `unlinkat` | Remove file/directory (tmpfs only) |
+| `chdir` / `getcwd` | Change/get working directory |
+| `dup3` | Duplicate fd |
+| `pipe2` | Create pipe (separate from VFS) |
+| `fcntl` | fd flags |
+| `readlinkat` | Read symbolic link (returns EINVAL — no symlinks yet) |

--- a/doc/ai/OVERVIEW.md
+++ b/doc/ai/OVERVIEW.md
@@ -15,6 +15,7 @@ Quick reference to find detailed documentation. Each file covers a specific subs
 | NETWORKING.md | UDP stack, sockets, packet flow | Network features/bugs |
 | DRIVERS.md | VirtIO, PCI enumeration, device tree | Device driver work |
 | TESTING.md | Unit tests, system tests, QEMU infrastructure | Writing/debugging tests |
+| FS.md | VFS layer, tmpfs, procfs, devfs, open files | Filesystem work, adding devices/proc entries |
 | DEBUGGING.md | Logging, backtrace, GDB, dump functions | Debugging kernel issues |
 
 ## Quick Navigation by Task
@@ -38,7 +39,7 @@ Quick reference to find detailed documentation. Each file covers a specific subs
 2. Check TESTING.md for system test patterns
 
 ### "I need to work on the filesystem"
-1. See `kernel/src/fs/` for VFS layer (vfs.rs, tmpfs.rs, procfs.rs, open_file.rs)
+1. Read FS.md for VFS architecture, mount layout, and how to add entries
 2. Check SYSCALLS.md for filesystem syscalls (openat, fstat, lseek, getdents64, etc.)
 
 ### "I need to work on networking"
@@ -58,7 +59,7 @@ kernel/src/
   processes/     - Process, thread, scheduler, loader
   syscalls/      - Syscall handlers and validation
   interrupts/    - Trap handler, PLIC, timer
-  fs/            - VFS layer (tmpfs, procfs, open file tracking)
+  fs/            - VFS layer (tmpfs, procfs, devfs, open file tracking)
   net/           - UDP network stack
   drivers/       - VirtIO drivers
   io/            - UART, stdin buffer

--- a/kernel/src/fs/devfs.rs
+++ b/kernel/src/fs/devfs.rs
@@ -64,7 +64,7 @@ impl VfsNode for DevZero {
     }
 }
 
-pub struct DevDir {
+pub(super) struct DevDir {
     ino: u64,
     null: VfsNodeRef,
     zero: VfsNodeRef,

--- a/kernel/src/fs/devfs.rs
+++ b/kernel/src/fs/devfs.rs
@@ -1,7 +1,7 @@
-use alloc::{string::String, sync::Arc, vec, vec::Vec};
+use alloc::sync::Arc;
 use headers::errno::Errno;
 
-use super::vfs::{DirEntry, NodeType, VfsNode, VfsNodeRef, alloc_ino};
+use super::vfs::{NodeType, StaticDir, VfsNode, alloc_ino};
 
 struct DevNull {
     ino: u64,
@@ -64,55 +64,9 @@ impl VfsNode for DevZero {
     }
 }
 
-pub(super) struct DevDir {
-    ino: u64,
-    null: VfsNodeRef,
-    zero: VfsNodeRef,
-}
-
-impl DevDir {
-    pub fn new() -> Arc<Self> {
-        Arc::new(Self {
-            ino: alloc_ino(),
-            null: Arc::new(DevNull { ino: alloc_ino() }),
-            zero: Arc::new(DevZero { ino: alloc_ino() }),
-        })
-    }
-}
-
-impl VfsNode for DevDir {
-    fn node_type(&self) -> NodeType {
-        NodeType::Directory
-    }
-
-    fn ino(&self) -> u64 {
-        self.ino
-    }
-
-    fn size(&self) -> usize {
-        0
-    }
-
-    fn lookup(&self, name: &str) -> Result<VfsNodeRef, Errno> {
-        match name {
-            "null" => Ok(self.null.clone()),
-            "zero" => Ok(self.zero.clone()),
-            _ => Err(Errno::ENOENT),
-        }
-    }
-
-    fn readdir(&self) -> Result<Vec<DirEntry>, Errno> {
-        Ok(vec![
-            DirEntry {
-                name: String::from("null"),
-                ino: self.null.ino(),
-                node_type: NodeType::File,
-            },
-            DirEntry {
-                name: String::from("zero"),
-                ino: self.zero.ino(),
-                node_type: NodeType::File,
-            },
-        ])
-    }
+pub(super) fn new() -> Arc<StaticDir> {
+    StaticDir::new(vec![
+        ("null", Arc::new(DevNull { ino: alloc_ino() })),
+        ("zero", Arc::new(DevZero { ino: alloc_ino() })),
+    ])
 }

--- a/kernel/src/fs/devfs.rs
+++ b/kernel/src/fs/devfs.rs
@@ -1,0 +1,118 @@
+use alloc::{string::String, sync::Arc, vec, vec::Vec};
+use headers::errno::Errno;
+
+use super::vfs::{DirEntry, NodeType, VfsNode, VfsNodeRef, alloc_ino};
+
+struct DevNull {
+    ino: u64,
+}
+
+impl VfsNode for DevNull {
+    fn node_type(&self) -> NodeType {
+        NodeType::File
+    }
+
+    fn ino(&self) -> u64 {
+        self.ino
+    }
+
+    fn size(&self) -> usize {
+        0
+    }
+
+    fn read(&self, _offset: usize, _buf: &mut [u8]) -> Result<usize, Errno> {
+        Ok(0)
+    }
+
+    fn write(&self, _offset: usize, data: &[u8]) -> Result<usize, Errno> {
+        Ok(data.len())
+    }
+
+    fn truncate(&self) -> Result<(), Errno> {
+        Ok(())
+    }
+}
+
+struct DevZero {
+    ino: u64,
+}
+
+impl VfsNode for DevZero {
+    fn node_type(&self) -> NodeType {
+        NodeType::File
+    }
+
+    fn ino(&self) -> u64 {
+        self.ino
+    }
+
+    fn size(&self) -> usize {
+        0
+    }
+
+    fn read(&self, _offset: usize, buf: &mut [u8]) -> Result<usize, Errno> {
+        buf.fill(0);
+        Ok(buf.len())
+    }
+
+    fn write(&self, _offset: usize, data: &[u8]) -> Result<usize, Errno> {
+        Ok(data.len())
+    }
+
+    fn truncate(&self) -> Result<(), Errno> {
+        Ok(())
+    }
+}
+
+pub struct DevDir {
+    ino: u64,
+    null: VfsNodeRef,
+    zero: VfsNodeRef,
+}
+
+impl DevDir {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            ino: alloc_ino(),
+            null: Arc::new(DevNull { ino: alloc_ino() }),
+            zero: Arc::new(DevZero { ino: alloc_ino() }),
+        })
+    }
+}
+
+impl VfsNode for DevDir {
+    fn node_type(&self) -> NodeType {
+        NodeType::Directory
+    }
+
+    fn ino(&self) -> u64 {
+        self.ino
+    }
+
+    fn size(&self) -> usize {
+        0
+    }
+
+    fn lookup(&self, name: &str) -> Result<VfsNodeRef, Errno> {
+        match name {
+            "null" => Ok(self.null.clone()),
+            "zero" => Ok(self.zero.clone()),
+            _ => Err(Errno::ENOENT),
+        }
+    }
+
+    fn readdir(&self) -> Result<Vec<DirEntry>, Errno> {
+        Ok(vec![
+            DirEntry {
+                name: String::from("null"),
+                ino: self.null.ino(),
+                node_type: NodeType::File,
+            },
+            DirEntry {
+                name: String::from("zero"),
+                ino: self.zero.ino(),
+                node_type: NodeType::File,
+            },
+        ])
+    }
+}

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -1,3 +1,4 @@
+mod devfs;
 pub mod open_file;
 mod procfs;
 mod tmpfs;
@@ -10,4 +11,5 @@ pub fn init() {
     vfs::mount("/", vfs::RootDir::new());
     vfs::mount("/tmp", tmpfs::TmpfsDir::new());
     vfs::mount("/proc", procfs::ProcDir::new());
+    vfs::mount("/dev", devfs::DevDir::new());
 }

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -10,6 +10,6 @@ pub use vfs::{resolve_parent, resolve_path, resolve_relative};
 pub fn init() {
     vfs::mount("/", vfs::RootDir::new());
     vfs::mount("/tmp", tmpfs::TmpfsDir::new());
-    vfs::mount("/proc", procfs::ProcDir::new());
-    vfs::mount("/dev", devfs::DevDir::new());
+    vfs::mount("/proc", procfs::new());
+    vfs::mount("/dev", devfs::new());
 }

--- a/kernel/src/fs/procfs.rs
+++ b/kernel/src/fs/procfs.rs
@@ -1,7 +1,7 @@
-use alloc::{string::String, sync::Arc, vec, vec::Vec};
+use alloc::sync::Arc;
 use headers::errno::Errno;
 
-use super::vfs::{DirEntry, NodeType, VfsNode, VfsNodeRef, alloc_ino};
+use super::vfs::{NodeType, StaticDir, VfsNode, VfsNodeRef, alloc_ino};
 
 struct ProcVersionFile {
     ino: u64,
@@ -37,46 +37,9 @@ impl VfsNode for ProcVersionFile {
     }
 }
 
-pub struct ProcDir {
-    ino: u64,
-    version: VfsNodeRef,
-}
-
-impl ProcDir {
-    pub fn new() -> Arc<Self> {
-        let version: VfsNodeRef = Arc::new(ProcVersionFile { ino: alloc_ino() });
-        Arc::new(Self {
-            ino: alloc_ino(),
-            version,
-        })
-    }
-}
-
-impl VfsNode for ProcDir {
-    fn node_type(&self) -> NodeType {
-        NodeType::Directory
-    }
-
-    fn ino(&self) -> u64 {
-        self.ino
-    }
-
-    fn size(&self) -> usize {
-        0
-    }
-
-    fn lookup(&self, name: &str) -> Result<VfsNodeRef, Errno> {
-        match name {
-            "version" => Ok(self.version.clone()),
-            _ => Err(Errno::ENOENT),
-        }
-    }
-
-    fn readdir(&self) -> Result<Vec<DirEntry>, Errno> {
-        Ok(vec![DirEntry {
-            name: String::from("version"),
-            ino: self.version.ino(),
-            node_type: NodeType::File,
-        }])
-    }
+pub(super) fn new() -> Arc<StaticDir> {
+    StaticDir::new(vec![(
+        "version",
+        Arc::new(ProcVersionFile { ino: alloc_ino() }) as VfsNodeRef,
+    )])
 }

--- a/kernel/src/fs/vfs.rs
+++ b/kernel/src/fs/vfs.rs
@@ -137,6 +137,53 @@ fn walk(mut node: VfsNodeRef, path: &str) -> Result<VfsNodeRef, Errno> {
     Ok(node)
 }
 
+pub(super) struct StaticDir {
+    ino: u64,
+    entries: BTreeMap<String, VfsNodeRef>,
+}
+
+impl StaticDir {
+    pub fn new(entries: Vec<(&str, VfsNodeRef)>) -> Arc<Self> {
+        Arc::new(Self {
+            ino: alloc_ino(),
+            entries: entries
+                .into_iter()
+                .map(|(n, v)| (String::from(n), v))
+                .collect(),
+        })
+    }
+}
+
+impl VfsNode for StaticDir {
+    fn node_type(&self) -> NodeType {
+        NodeType::Directory
+    }
+
+    fn ino(&self) -> u64 {
+        self.ino
+    }
+
+    fn size(&self) -> usize {
+        0
+    }
+
+    fn lookup(&self, name: &str) -> Result<VfsNodeRef, Errno> {
+        self.entries.get(name).cloned().ok_or(Errno::ENOENT)
+    }
+
+    fn readdir(&self) -> Result<Vec<DirEntry>, Errno> {
+        Ok(self
+            .entries
+            .iter()
+            .map(|(name, node)| DirEntry {
+                name: name.clone(),
+                ino: node.ino(),
+                node_type: node.node_type(),
+            })
+            .collect())
+    }
+}
+
 pub(super) struct RootDir {
     ino: u64,
 }

--- a/system-tests/src/tests/vfs.rs
+++ b/system-tests/src/tests/vfs.rs
@@ -31,6 +31,7 @@ async fn ls_root() -> anyhow::Result<()> {
     let output = solaya.run_prog("ls-test /").await?;
     assert!(output.contains("tmp"), "ls / should list tmp");
     assert!(output.contains("proc"), "ls / should list proc");
+    assert!(output.contains("dev"), "ls / should list dev");
     Ok(())
 }
 
@@ -62,5 +63,33 @@ async fn vfs_roundtrip() -> anyhow::Result<()> {
     assert!(output.contains("OK proc_version"));
     assert!(output.contains("OK remove"));
     assert!(output.contains("OK gone"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn devfs_null_and_zero() -> anyhow::Result<()> {
+    let mut solaya = QemuInstance::start().await?;
+    let output = solaya.run_prog("devfs_test").await?;
+    assert!(output.contains("OK null_write"));
+    assert!(output.contains("OK null_read"));
+    assert!(output.contains("OK zero_read"));
+    assert!(output.contains("OK zero_write"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn cat_dev_null() -> anyhow::Result<()> {
+    let mut solaya = QemuInstance::start().await?;
+    let output = solaya.run_prog("cat /dev/null").await?;
+    assert_eq!(output, "");
+    Ok(())
+}
+
+#[tokio::test]
+async fn ls_dev() -> anyhow::Result<()> {
+    let mut solaya = QemuInstance::start().await?;
+    let output = solaya.run_prog("ls-test /dev").await?;
+    assert!(output.contains("null"), "ls /dev should list null");
+    assert!(output.contains("zero"), "ls /dev should list zero");
     Ok(())
 }

--- a/userspace/src/bin/devfs_test.rs
+++ b/userspace/src/bin/devfs_test.rs
@@ -1,0 +1,41 @@
+use std::io::{Read, Write};
+
+fn main() {
+    // Test 1: Write to /dev/null
+    {
+        let mut f = std::fs::File::create("/dev/null").expect("open /dev/null for write failed");
+        f.write_all(b"discard this")
+            .expect("write to /dev/null failed");
+    }
+    println!("OK null_write");
+
+    // Test 2: Read from /dev/null (should return EOF immediately)
+    {
+        let mut f = std::fs::File::open("/dev/null").expect("open /dev/null for read failed");
+        let mut buf = [0u8; 64];
+        let n = f.read(&mut buf).expect("read from /dev/null failed");
+        assert_eq!(n, 0, "/dev/null read should return 0 bytes");
+    }
+    println!("OK null_read");
+
+    // Test 3: Read from /dev/zero (should return zero-filled bytes)
+    {
+        let mut f = std::fs::File::open("/dev/zero").expect("open /dev/zero for read failed");
+        let mut buf = [0xFFu8; 64];
+        let n = f.read(&mut buf).expect("read from /dev/zero failed");
+        assert_eq!(n, 64, "/dev/zero should fill entire buffer");
+        assert!(
+            buf.iter().all(|&b| b == 0),
+            "/dev/zero should return all zeros"
+        );
+    }
+    println!("OK zero_read");
+
+    // Test 4: Write to /dev/zero
+    {
+        let mut f = std::fs::File::create("/dev/zero").expect("open /dev/zero for write failed");
+        f.write_all(b"discard this too")
+            .expect("write to /dev/zero failed");
+    }
+    println!("OK zero_write");
+}


### PR DESCRIPTION
## Summary
- Add a new `devfs` filesystem mounted at `/dev` with two device files:
  - `/dev/null` — reads return EOF, writes discard data
  - `/dev/zero` — reads return zero-filled bytes, writes discard data
- Extract shared `StaticDir` type in `vfs.rs` to eliminate duplicated read-only directory logic between `devfs` and `procfs` — both `DevDir` and `ProcDir` are removed in favor of simple builder functions that construct a `StaticDir`
- Add userspace test program (`devfs_test`) exercising read/write on both devices
- Add 3 system tests (`devfs_null_and_zero`, `cat_dev_null`, `ls_dev`) and update `ls_root` to verify `/dev`

## Test plan
- [x] `just clippy` — no warnings
- [x] `just test` — all 138 unit tests + 43 system tests pass
- [x] Commit review passed with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)