### PR TITLE
feat: add VirtIO RNG driver with /dev/random and AT_RANDOM

### DIFF
--- a/kernel/src/drivers/virtio/mod.rs
+++ b/kernel/src/drivers/virtio/mod.rs
@@ -1,4 +1,5 @@
 pub mod block;
 mod capability;
 pub mod net;
+pub mod rng;
 mod virtqueue;

--- a/kernel/src/drivers/virtio/rng.rs
+++ b/kernel/src/drivers/virtio/rng.rs
@@ -1,0 +1,225 @@
+use alloc::vec;
+
+use crate::{
+    drivers::virtio::{
+        capability::{
+            DEVICE_STATUS_ACKNOWLEDGE, DEVICE_STATUS_DRIVER, DEVICE_STATUS_DRIVER_OK,
+            DEVICE_STATUS_FAILED, DEVICE_STATUS_FEATURES_OK, VIRTIO_DEVICE_ID, VIRTIO_F_VERSION_1,
+            VIRTIO_PCI_CAP_COMMON_CFG, VIRTIO_PCI_CAP_NOTIFY_CFG, VIRTIO_VENDOR_ID,
+            VIRTIO_VENDOR_SPECIFIC_CAPABILITY_ID, virtio_pci_cap, virtio_pci_common_cfg,
+            virtio_pci_notify_cap,
+        },
+        virtqueue::{BufferDirection, VirtQueue},
+    },
+    info,
+    klibc::{MMIO, Spinlock, util::is_power_of_2_or_zero},
+    pci::PCIDevice,
+};
+
+const QUEUE_SIZE: usize = 0x100;
+const VIRTIO_RNG_SUBSYSTEM_ID: u16 = 4;
+const SPIN_LIMIT: usize = 1_000_000;
+
+pub struct RngDevice {
+    common_cfg: MMIO<virtio_pci_common_cfg>,
+    request_queue: VirtQueue<QUEUE_SIZE>,
+}
+
+static RNG_DEVICE: Spinlock<Option<RngDevice>> = Spinlock::new(None);
+
+pub fn set_device(device: RngDevice) {
+    *RNG_DEVICE.lock() = Some(device);
+}
+
+pub fn read_random(buf: &mut [u8]) {
+    let mut guard = RNG_DEVICE.lock();
+    let dev = guard.as_mut().expect("RNG device not initialized");
+    dev.read(buf);
+}
+
+pub fn is_available() -> bool {
+    RNG_DEVICE.lock().is_some()
+}
+
+impl RngDevice {
+    pub fn is_virtio_rng(device: &PCIDevice) -> bool {
+        let cs = device.configuration_space();
+        cs.vendor_id().read() == VIRTIO_VENDOR_ID
+            && VIRTIO_DEVICE_ID.contains(&cs.device_id().read())
+            && cs.subsystem_id().read() == VIRTIO_RNG_SUBSYSTEM_ID
+    }
+
+    pub fn initialize(mut pci_device: PCIDevice) -> Result<RngDevice, &'static str> {
+        let capabilities = pci_device.capabilities();
+        let virtio_capabilities: alloc::vec::Vec<MMIO<virtio_pci_cap>> = capabilities
+            .filter(|cap| cap.id().read() == VIRTIO_VENDOR_SPECIFIC_CAPABILITY_ID)
+            // SAFETY: VirtIO vendor-specific capabilities have the virtio_pci_cap
+            // layout per the VirtIO spec.
+            .map(|cap| unsafe { cap.new_type::<virtio_pci_cap>() })
+            .collect();
+
+        let common_cfg_cap = virtio_capabilities
+            .iter()
+            .find(|cap| cap.cfg_type().read() == VIRTIO_PCI_CAP_COMMON_CFG)
+            .ok_or("Common configuration capability not found")?;
+
+        let config_bar = pci_device.get_or_initialize_bar(common_cfg_cap.bar().read());
+        let common_cfg: MMIO<virtio_pci_common_cfg> = MMIO::new(
+            (config_bar.cpu_address + common_cfg_cap.offset().read() as usize).as_usize(),
+        );
+
+        // Reset and acknowledge
+        common_cfg.device_status().write(0x0);
+        #[allow(clippy::while_immutable_condition)]
+        while common_cfg.device_status().read() != 0x0 {}
+
+        let mut device_status = common_cfg.device_status();
+        device_status |= DEVICE_STATUS_ACKNOWLEDGE;
+        assert!(
+            device_status.read() & DEVICE_STATUS_FAILED == 0,
+            "Device failed"
+        );
+        device_status |= DEVICE_STATUS_DRIVER;
+        assert!(
+            device_status.read() & DEVICE_STATUS_FAILED == 0,
+            "Device failed"
+        );
+
+        // Negotiate features (only VIRTIO_F_VERSION_1)
+        common_cfg.device_feature_select().write(0);
+        let mut device_features = common_cfg.device_feature().read() as u64;
+        common_cfg.device_feature_select().write(1);
+        device_features |= (common_cfg.device_feature().read() as u64) << 32;
+
+        assert!(
+            device_features & VIRTIO_F_VERSION_1 != 0,
+            "Virtio version 1 not supported"
+        );
+
+        let wanted_features: u64 = VIRTIO_F_VERSION_1;
+
+        common_cfg.driver_feature_select().write(0);
+        common_cfg
+            .driver_feature()
+            .write(u32::try_from(wanted_features & 0xFFFF_FFFF).expect("masked to 32 bits"));
+        common_cfg.driver_feature_select().write(1);
+        common_cfg
+            .driver_feature()
+            .write(u32::try_from(wanted_features >> 32).expect("high 32 bits fit in u32"));
+
+        device_status |= DEVICE_STATUS_FEATURES_OK;
+        assert!(
+            device_status.read() & DEVICE_STATUS_FAILED == 0,
+            "Device failed"
+        );
+        assert!(
+            device_status.read() & DEVICE_STATUS_FEATURES_OK != 0,
+            "Device features not ok"
+        );
+
+        // Setup notification
+        let notify_cfg_cap = virtio_capabilities
+            .iter()
+            .find(|cap| cap.cfg_type().read() == VIRTIO_PCI_CAP_NOTIFY_CFG)
+            .ok_or("Notification capability not found")?;
+        // SAFETY: The notify capability extends virtio_pci_cap with an
+        // additional notify_off_multiplier field per the VirtIO spec.
+        let notify_cfg = unsafe { notify_cfg_cap.new_type::<virtio_pci_notify_cap>() };
+
+        assert!(
+            is_power_of_2_or_zero(notify_cfg.notify_off_multiplier().read()),
+            "Notify offset multiplier must be a power of 2 or zero"
+        );
+
+        let notify_bar = pci_device.get_or_initialize_bar(notify_cfg.cap().bar().read());
+
+        // Setup single request queue at index 0.
+        // Write our desired queue size to the device (VirtIO spec allows
+        // reducing from the device maximum).
+        common_cfg.queue_select().write(0);
+        #[allow(clippy::cast_possible_truncation)]
+        let queue_size = QUEUE_SIZE as u16;
+        common_cfg.queue_size().write(queue_size);
+        let mut request_queue: VirtQueue<QUEUE_SIZE> = VirtQueue::new(queue_size, 0);
+
+        let notify_mmio: MMIO<u16> = MMIO::new(
+            notify_bar.cpu_address.as_usize()
+                + notify_cfg.cap().offset().read() as usize
+                + common_cfg.queue_notify_off().read() as usize
+                    * notify_cfg.notify_off_multiplier().read() as usize,
+        );
+        request_queue.set_notify(notify_mmio);
+
+        // Configure queue on device
+        common_cfg.queue_select().write(0);
+        common_cfg
+            .queue_desc()
+            .write(request_queue.descriptor_area_physical_address());
+        common_cfg
+            .queue_driver()
+            .write(request_queue.driver_area_physical_address());
+        common_cfg
+            .queue_device()
+            .write(request_queue.device_area_physical_address());
+        common_cfg.queue_enable().write(1);
+
+        // Mark driver ready
+        device_status |= DEVICE_STATUS_DRIVER_OK;
+        assert!(
+            device_status.read() & DEVICE_STATUS_FAILED == 0,
+            "Device failed"
+        );
+
+        // Enable Bus Master for DMA and clear Interrupt Disable for legacy INTx
+        pci_device
+            .configuration_space_mut()
+            .set_command_register_bits(crate::pci::command_register::BUS_MASTER);
+        pci_device
+            .configuration_space_mut()
+            .clear_command_register_bits(crate::pci::command_register::INTERRUPT_DISABLE);
+
+        info!("Successfully initialized VirtIO RNG device");
+
+        Ok(RngDevice {
+            common_cfg,
+            request_queue,
+        })
+    }
+
+    fn read(&mut self, buf: &mut [u8]) {
+        let mut filled = 0;
+        while filled < buf.len() {
+            let request_len = core::cmp::min(buf.len() - filled, 256);
+            let request_buf = vec![0u8; request_len];
+            self.request_queue
+                .put_buffer(request_buf, BufferDirection::DeviceWritable)
+                .expect("Must be able to submit RNG request");
+            self.request_queue.notify();
+
+            let mut spins = 0;
+            let received = loop {
+                let buffers = self.request_queue.receive_buffer();
+                if !buffers.is_empty() {
+                    break buffers;
+                }
+                spins += 1;
+                assert!(spins < SPIN_LIMIT, "VirtIO RNG device not responding");
+                core::hint::spin_loop();
+            };
+
+            for used in received {
+                let data = used.buffers.into_first();
+                let copy_len = core::cmp::min(data.len(), buf.len() - filled);
+                buf[filled..filled + copy_len].copy_from_slice(&data[..copy_len]);
+                filled += copy_len;
+            }
+        }
+    }
+}
+
+impl Drop for RngDevice {
+    fn drop(&mut self) {
+        info!("Reset RNG device because of drop");
+        self.common_cfg.device_status().write(0x0);
+    }
+}

--- a/kernel/src/drivers/virtio/rng.rs
+++ b/kernel/src/drivers/virtio/rng.rs
@@ -16,7 +16,7 @@ use crate::{
     pci::PCIDevice,
 };
 
-const QUEUE_SIZE: usize = 0x100;
+const QUEUE_SIZE: usize = 0x10;
 const VIRTIO_RNG_SUBSYSTEM_ID: u16 = 4;
 const SPIN_LIMIT: usize = 1_000_000;
 

--- a/kernel/src/fs/devfs.rs
+++ b/kernel/src/fs/devfs.rs
@@ -1,7 +1,10 @@
 use alloc::{collections::BTreeMap, string::String, sync::Arc, vec::Vec};
 use headers::errno::Errno;
 
-use crate::{drivers::virtio::block, klibc::Spinlock};
+use crate::{
+    drivers::virtio::{block, rng},
+    klibc::Spinlock,
+};
 
 use super::vfs::{DirEntry, NodeType, VfsNode, VfsNodeRef, alloc_ino};
 
@@ -94,6 +97,37 @@ impl VfsNode for DevBlock {
     }
 }
 
+struct DevRandom {
+    ino: u64,
+}
+
+impl VfsNode for DevRandom {
+    fn node_type(&self) -> NodeType {
+        NodeType::File
+    }
+
+    fn ino(&self) -> u64 {
+        self.ino
+    }
+
+    fn size(&self) -> usize {
+        0
+    }
+
+    fn read(&self, _offset: usize, buf: &mut [u8]) -> Result<usize, Errno> {
+        rng::read_random(buf);
+        Ok(buf.len())
+    }
+
+    fn write(&self, _offset: usize, data: &[u8]) -> Result<usize, Errno> {
+        Ok(data.len())
+    }
+
+    fn truncate(&self) -> Result<(), Errno> {
+        Ok(())
+    }
+}
+
 struct DevfsDir {
     ino: u64,
     entries: Spinlock<BTreeMap<String, VfsNodeRef>>,
@@ -149,6 +183,15 @@ pub(super) fn new() -> VfsNodeRef {
     });
     *DEVFS.lock() = Some(dir.clone());
     dir
+}
+
+pub fn register_random_device() {
+    let node: VfsNodeRef = Arc::new(DevRandom { ino: alloc_ino() });
+    let dir = DEVFS
+        .lock()
+        .clone()
+        .expect("devfs must be initialized before registering devices");
+    dir.entries.lock().insert(String::from("random"), node);
 }
 
 pub fn register_block_device(index: usize) {

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -189,6 +189,17 @@ extern "C" fn kernel_init(hart_id: usize, device_tree_pointer: *const ()) -> ! {
         plic::init_virtio_block_interrupt(plic_irq);
     }
 
+    if let Some(i) = pci_devices
+        .iter()
+        .position(drivers::virtio::rng::RngDevice::is_virtio_rng)
+    {
+        let device = pci_devices.swap_remove(i);
+        let rng = drivers::virtio::rng::RngDevice::initialize(device)
+            .expect("RNG device initialization must work.");
+        drivers::virtio::rng::set_device(rng);
+        fs::devfs::register_random_device();
+    }
+
     processes::kernel_tasks::create_worker_thread();
 
     info!("kernel_init done! Starting other harts");

--- a/kernel/src/memory/heap.rs
+++ b/kernel/src/memory/heap.rs
@@ -149,7 +149,7 @@ impl<Allocator: PageAllocator> Heap<Allocator> {
     }
 
     fn is_page_allocator_allocation(&self, layout: &Layout) -> bool {
-        layout.size() >= PAGE_SIZE || layout.align() == PAGE_SIZE
+        layout.size() >= PAGE_SIZE || layout.align() > FreeBlock::DATA_ALIGNMENT
     }
 
     fn alloc(&mut self, layout: core::alloc::Layout) -> *mut u8 {

--- a/kernel/src/processes/loader.rs
+++ b/kernel/src/processes/loader.rs
@@ -1,6 +1,6 @@
 use alloc::{collections::BTreeMap, string::ToString, vec::Vec};
 use common::errors::LoaderError;
-use headers::syscall_types::{AT_NULL, AT_PAGESZ, AT_PHDR, AT_PHENT, AT_PHNUM};
+use headers::syscall_types::{AT_NULL, AT_PAGESZ, AT_PHDR, AT_PHENT, AT_PHNUM, AT_RANDOM};
 
 use crate::klibc::{util::align_up, writable_buffer::WritableBuffer};
 
@@ -40,6 +40,8 @@ struct AuxvInfo {
     phnum: usize,
 }
 
+const AT_RANDOM_SIZE: usize = 16;
+
 fn set_up_arguments(
     stack: &mut [u8],
     name: &str,
@@ -48,11 +50,17 @@ fn set_up_arguments(
     auxv_info: &AuxvInfo,
 ) -> Result<VirtAddr, LoaderError> {
     // layout:
-    // [argc, argv[0]..argv[n], NULL, envp[0]..envp[m], NULL, auxv..., name\0, args\0..., env\0...]
+    // [argc, argv[0]..argv[n], NULL, envp[0]..envp[m], NULL, auxv..., name\0, args\0..., env\0..., random(16)]
     let argc = 1 + args.len(); // name + amount of args
     let mut argv = vec![0usize; args.len() + 2]; // number of args plus name and null terminator
     let mut envp = vec![0usize; env.len() + 1]; // env entries + NULL
-    let auxv = [
+
+    let mut random_bytes = [0u8; AT_RANDOM_SIZE];
+    if crate::drivers::virtio::rng::is_available() {
+        crate::drivers::virtio::rng::read_random(&mut random_bytes);
+    }
+
+    let mut auxv = [
         AT_PAGESZ as usize,
         PAGE_SIZE,
         AT_PHDR as usize,
@@ -61,9 +69,12 @@ fn set_up_arguments(
         auxv_info.phent,
         AT_PHNUM as usize,
         auxv_info.phnum,
+        AT_RANDOM as usize,
+        0, // placeholder, patched below
         AT_NULL as usize,
         0,
     ];
+
     let strings = [name]
         .iter()
         .chain(args)
@@ -75,13 +86,18 @@ fn set_up_arguments(
     let start_of_strings_offset =
         core::mem::size_of_val(&argc) + argv.in_bytes() + envp.in_bytes() + auxv.in_bytes();
 
-    let total_length = align_up(start_of_strings_offset + strings.in_bytes(), 8);
+    let random_bytes_offset = start_of_strings_offset + strings.in_bytes();
+    let total_length = align_up(random_bytes_offset + AT_RANDOM_SIZE, 8);
 
     if total_length >= stack.len() {
         return Err(LoaderError::StackToSmall);
     }
 
     let real_start = STACK_START - total_length + 1;
+
+    // Patch AT_RANDOM to point at the random bytes on the stack
+    auxv[9] = (real_start + random_bytes_offset).as_usize();
+
     let mut addr_current_string = real_start + start_of_strings_offset;
 
     // Patch argv pointers
@@ -129,6 +145,10 @@ fn set_up_arguments(
 
     writable_buffer
         .write_slice(&strings)
+        .map_err(|_| LoaderError::StackToSmall)?;
+
+    writable_buffer
+        .write_slice(&random_bytes)
         .map_err(|_| LoaderError::StackToSmall)?;
 
     // We want to point into the arguments

--- a/kernel/src/processes/loader.rs
+++ b/kernel/src/processes/loader.rs
@@ -95,8 +95,13 @@ fn set_up_arguments(
 
     let real_start = STACK_START - total_length + 1;
 
-    // Patch AT_RANDOM to point at the random bytes on the stack
-    auxv[9] = (real_start + random_bytes_offset).as_usize();
+    // Patch AT_RANDOM value to point at the random bytes on the stack.
+    // Search only keys (even indices) to avoid matching a value that happens to equal AT_RANDOM.
+    let at_random_pair_idx = auxv
+        .chunks(2)
+        .position(|pair| pair[0] == AT_RANDOM as usize)
+        .expect("AT_RANDOM must be in auxv");
+    auxv[at_random_pair_idx * 2 + 1] = (real_start + random_bytes_offset).as_usize();
 
     let mut addr_current_string = real_start + start_of_strings_offset;
 

--- a/qemu_wrapper.sh
+++ b/qemu_wrapper.sh
@@ -11,7 +11,8 @@ QEMU_CMD="qemu-system-riscv64 \
     -cpu rv64 \
     -m 512M \
     -nographic \
-    -serial mon:stdio"
+    -serial mon:stdio \
+    -device virtio-rng-pci"
 
 # Process options
 while [[ $# -gt 0 ]]; do

--- a/system-tests/src/tests/mod.rs
+++ b/system-tests/src/tests/mod.rs
@@ -7,6 +7,7 @@ mod mutex;
 mod net;
 mod panic;
 mod process_relation;
+mod rng;
 mod shell;
 mod signals;
 mod sleep;

--- a/system-tests/src/tests/rng.rs
+++ b/system-tests/src/tests/rng.rs
@@ -1,0 +1,10 @@
+use crate::infra::qemu::QemuInstance;
+
+#[tokio::test]
+async fn dev_random_and_at_random() -> anyhow::Result<()> {
+    let mut solaya = QemuInstance::start().await?;
+    let output = solaya.run_prog("rng_test").await?;
+    assert!(output.contains("OK dev_random"));
+    assert!(output.contains("OK at_random"));
+    Ok(())
+}

--- a/system-tests/src/tests/vfs.rs
+++ b/system-tests/src/tests/vfs.rs
@@ -91,6 +91,7 @@ async fn ls_dev() -> anyhow::Result<()> {
     let output = solaya.run_prog("ls-test /dev").await?;
     assert!(output.contains("null"), "ls /dev should list null");
     assert!(output.contains("zero"), "ls /dev should list zero");
+    assert!(output.contains("random"), "ls /dev should list random");
     assert!(
         !output.contains("vda"),
         "/dev/vda should not appear without --block"

--- a/todo/overview.md
+++ b/todo/overview.md
@@ -9,8 +9,6 @@ This document contains research summaries for planned future enhancements. Each 
 3. [Port Doom](#3-port-doom)
 4. [Minimal TCP Implementation](#4-minimal-tcp-implementation)
 5. [Dynamic Linking](#5-dynamic-linking)
-6. [QEMU Random Device Driver](#6-qemu-random-device-driver)
-
 ---
 
 ## 1. ext2 Filesystem
@@ -335,84 +333,6 @@ Four-way handshake (FIN, ACK, FIN, ACK) - can optimize to three-way.
 **Main Blocker:** Persistent filesystem (ext2 + block device) - currently embeds all binaries
 
 **Estimated effort:** 2-4 weeks once filesystem exists
-
----
-
-## 6. QEMU Random Device Driver
-
-**Complexity:** Low to Medium
-
-### Device Specification
-- VirtIO Device ID: **4**
-- PCI Subsystem ID: **4** (differs from network = 1)
-- Single virtqueue for entropy requests
-- Simpler than network device (no config registers like MAC address)
-
-### Driver Implementation
-**Based on existing virtio-net driver:**
-
-**Detection:**
-```rust
-pub fn is_virtio_rng(device: &PCIDevice) -> bool {
-    device.subsystem_id().read() == 4  // RNG subsystem ID
-}
-```
-
-**Operation:**
-1. Reuse virtqueue infrastructure
-2. Follow network device initialization pattern
-3. Single receive queue with `BufferDirection::DeviceWritable`
-4. No transmit queue needed (read-only device)
-5. Device writes random bytes into guest buffers
-
-**Simpler than network:**
-- No device-specific configuration
-- No MAC address or status registers
-- Single queue
-- No packet headers (raw bytes)
-
-### Linux Auxiliary Vector (auxv)
-
-**AT_RANDOM:**
-- Provides pointer to **16 random bytes**
-- Constant for process lifetime
-- Used for ASLR and runtime security
-
-**Current auxv** (`kernel/src/processes/loader.rs:37-65`):
-- `AT_PAGESZ`, `AT_PHDR`, `AT_PHENT`, `AT_PHNUM`, `AT_NULL`
-
-**Required changes:**
-1. Allocate 16-byte buffer
-2. Fill from virtio-rng during kernel init
-3. Add `AT_RANDOM` entry to auxv:
-   ```rust
-   AT_RANDOM as usize,
-   random_bytes_ptr as usize,
-   ```
-
-### Integration Points
-
-**Kernel init** (`kernel/src/main.rs:140-150`):
-- Enumerate PCI devices
-- Detect virtio-rng alongside virtio-net
-- Initialize driver, generate entropy pool
-- Store in global accessible to loader
-
-**Process creation** (`kernel/src/processes/loader.rs:130`):
-- Modify `set_up_arguments()` to include AT_RANDOM
-- Generate 16 bytes per process (or use pool)
-
-**Headers:**
-- Add `AT_RANDOM` constant to `headers/syscall_types`
-
-### Implementation Order
-1. Implement virtio-rng driver
-2. Add kernel storage for random bytes
-3. Add `AT_RANDOM` constant
-4. Modify auxv construction
-5. System test to verify `getauxval(AT_RANDOM)` works
-
-**Estimated effort:** 1-2 weeks
 
 ## Clarifying Questions
 

--- a/userspace/src/bin/rng_test.rs
+++ b/userspace/src/bin/rng_test.rs
@@ -1,0 +1,44 @@
+use std::io::Read;
+
+const AT_RANDOM: u64 = 25;
+
+unsafe extern "C" {
+    fn getauxval(typ: u64) -> usize;
+}
+
+fn main() {
+    // Test 1: Read from /dev/random
+    {
+        let mut f = std::fs::File::open("/dev/random").expect("open /dev/random failed");
+        let mut buf = [0u8; 32];
+        let n = f.read(&mut buf).expect("read from /dev/random failed");
+        assert_eq!(n, 32, "/dev/random should return 32 bytes");
+        assert!(
+            buf.iter().any(|&b| b != 0),
+            "/dev/random should return non-zero bytes"
+        );
+        print!("random bytes:");
+        for b in &buf {
+            print!(" {:02x}", b);
+        }
+        println!();
+    }
+    println!("OK dev_random");
+
+    // Test 2: AT_RANDOM from auxiliary vector
+    {
+        let ptr = unsafe { getauxval(AT_RANDOM) };
+        assert!(ptr != 0, "AT_RANDOM should be non-zero");
+        let random = unsafe { core::slice::from_raw_parts(ptr as *const u8, 16) };
+        assert!(
+            random.iter().any(|&b| b != 0),
+            "AT_RANDOM should contain non-zero bytes"
+        );
+        print!("at_random bytes:");
+        for b in random {
+            print!(" {:02x}", b);
+        }
+        println!();
+    }
+    println!("OK at_random");
+}


### PR DESCRIPTION
## Summary
- Add VirtIO RNG driver (`virtio-rng-pci`) with `/dev/random` device and `AT_RANDOM` auxiliary vector support
- Fix heap allocator to route high-alignment allocations (align > 8) to the page allocator, preventing panics on VirtQueue descriptor arrays
- Replace hardcoded `auxv[9]` index with `position()`-based lookup for AT_RANDOM, making auxv patching robust to ordering changes

## Details

**VirtIO RNG driver** (`kernel/src/drivers/virtio/rng.rs`):
- Detects virtio-rng PCI device (subsystem ID 4) during kernel init
- Follows existing virtio driver pattern (capability parsing, feature negotiation, virtqueue setup)
- Exposes `read_random()` API used by devfs and process loader
- Uses small queue size (16 entries) since only one request is submitted at a time

**`/dev/random`** (`kernel/src/fs/devfs.rs`):
- Registered during kernel init when RNG device is available
- Reads fill the buffer with hardware random bytes; writes are accepted and discarded

**AT_RANDOM** (`kernel/src/processes/loader.rs`):
- 16 random bytes placed on the process stack, pointer passed via `AT_RANDOM` auxv entry
- Falls back to zero bytes if RNG device is unavailable

**Heap fix** (`kernel/src/memory/heap.rs`):
- Changed `is_page_allocator_allocation()` from `align == PAGE_SIZE` to `align > FreeBlock::DATA_ALIGNMENT`
- Prevents panic on small allocations needing alignment > 8 (e.g. virtqueue descriptors with align=16)

## Test plan
- [x] `just clippy` — no warnings
- [x] `just test` — 153 unit tests + 47 system tests pass
- [x] New system test `dev_random_and_at_random` verifies both `/dev/random` reads and `AT_RANDOM` auxv entry
- [x] `ls /dev` test updated to check for `random` device

🤖 Generated with [Claude Code](https://claude.com/claude-code)