### PR TITLE
feat: read-only ext2 filesystem driver

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -98,6 +98,7 @@
               pwndbg.packages.${system}.default
               pkgs.typos-lsp
               pkgs.dtc
+              pkgs.e2fsprogs
             ]
             ++ basePackages;
             shellHook = hook;

--- a/kernel/src/drivers/virtio/block.rs
+++ b/kernel/src/drivers/virtio/block.rs
@@ -154,6 +154,10 @@ pub fn assign_block_device(device: BlockDevice) -> usize {
     index
 }
 
+pub fn device_count() -> usize {
+    BLOCK_DEVICES.lock().len()
+}
+
 pub fn capacity(index: usize) -> u64 {
     BLOCK_DEVICES
         .lock()

--- a/kernel/src/fs/ext2/dir.rs
+++ b/kernel/src/fs/ext2/dir.rs
@@ -1,0 +1,61 @@
+use alloc::{collections::BTreeMap, string::String, sync::Arc, vec::Vec};
+use headers::errno::Errno;
+
+use crate::fs::vfs::{DirEntry, NodeType, VfsNode, VfsNodeRef};
+
+pub struct Ext2Dir {
+    ino: u64,
+    children: BTreeMap<String, VfsNodeRef>,
+}
+
+impl Ext2Dir {
+    pub fn new(ino: u64, children: BTreeMap<String, VfsNodeRef>) -> Arc<Self> {
+        Arc::new(Self { ino, children })
+    }
+}
+
+impl VfsNode for Ext2Dir {
+    fn node_type(&self) -> NodeType {
+        NodeType::Directory
+    }
+
+    fn ino(&self) -> u64 {
+        self.ino
+    }
+
+    fn size(&self) -> usize {
+        0
+    }
+
+    fn lookup(&self, name: &str) -> Result<VfsNodeRef, Errno> {
+        self.children.get(name).cloned().ok_or(Errno::ENOENT)
+    }
+
+    fn readdir(&self) -> Result<Vec<DirEntry>, Errno> {
+        Ok(self
+            .children
+            .iter()
+            .map(|(name, node)| DirEntry {
+                name: name.clone(),
+                ino: node.ino(),
+                node_type: node.node_type(),
+            })
+            .collect())
+    }
+
+    fn create(&self, _name: &str, _node_type: NodeType) -> Result<VfsNodeRef, Errno> {
+        Err(Errno::EROFS)
+    }
+
+    fn unlink(&self, _name: &str) -> Result<(), Errno> {
+        Err(Errno::EROFS)
+    }
+
+    fn read(&self, _offset: usize, _buf: &mut [u8]) -> Result<usize, Errno> {
+        Err(Errno::EISDIR)
+    }
+
+    fn write(&self, _offset: usize, _data: &[u8]) -> Result<usize, Errno> {
+        Err(Errno::EISDIR)
+    }
+}

--- a/kernel/src/fs/ext2/file.rs
+++ b/kernel/src/fs/ext2/file.rs
@@ -1,0 +1,52 @@
+use alloc::{sync::Arc, vec::Vec};
+use headers::errno::Errno;
+
+use crate::fs::vfs::{NodeType, VfsNode};
+
+pub struct Ext2File {
+    ino: u64,
+    data: Vec<u8>,
+    file_size: usize,
+}
+
+impl Ext2File {
+    pub fn new(ino: u64, data: Vec<u8>, file_size: usize) -> Arc<Self> {
+        Arc::new(Self {
+            ino,
+            data,
+            file_size,
+        })
+    }
+}
+
+impl VfsNode for Ext2File {
+    fn node_type(&self) -> NodeType {
+        NodeType::File
+    }
+
+    fn ino(&self) -> u64 {
+        self.ino
+    }
+
+    fn size(&self) -> usize {
+        self.file_size
+    }
+
+    fn read(&self, offset: usize, buf: &mut [u8]) -> Result<usize, Errno> {
+        if offset >= self.file_size {
+            return Ok(0);
+        }
+        let available = &self.data[offset..self.file_size];
+        let n = buf.len().min(available.len());
+        buf[..n].copy_from_slice(&available[..n]);
+        Ok(n)
+    }
+
+    fn write(&self, _offset: usize, _data: &[u8]) -> Result<usize, Errno> {
+        Err(Errno::EROFS)
+    }
+
+    fn truncate(&self) -> Result<(), Errno> {
+        Err(Errno::EROFS)
+    }
+}

--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -1,0 +1,188 @@
+use alloc::{vec, vec::Vec};
+
+use crate::{drivers::virtio::block, klibc::util::BufferExtension};
+
+use super::structures::{
+    EXT2_DIND_BLOCK, EXT2_IND_BLOCK, EXT2_NDIR_BLOCKS, EXT2_TIND_BLOCK, Ext2BlockGroupDescriptor,
+    Ext2Inode, Ext2Superblock,
+};
+
+#[allow(clippy::cast_possible_truncation)]
+pub async fn read_inode(
+    dev: usize,
+    sb: &Ext2Superblock,
+    bgds: &[Ext2BlockGroupDescriptor],
+    inode_number: u32,
+) -> Ext2Inode {
+    assert!(inode_number >= 1, "inode numbers start at 1");
+    let group = ((inode_number - 1) / sb.s_inodes_per_group) as usize;
+    let index = ((inode_number - 1) % sb.s_inodes_per_group) as usize;
+    let inode_size = sb.inode_size();
+    let block_size = sb.block_size();
+
+    let offset = bgds[group].bg_inode_table as usize * block_size + index * inode_size;
+    let mut buf = vec![0u8; inode_size];
+    let n = block::read(dev, offset, &mut buf)
+        .await
+        .expect("inode read must succeed");
+    assert!(n == inode_size, "short inode read");
+
+    // Copy into a properly aligned Ext2Inode
+    let mut inode = core::mem::MaybeUninit::<Ext2Inode>::uninit();
+    let inode_bytes = core::mem::size_of::<Ext2Inode>();
+    // SAFETY: We copy exactly the right number of bytes into uninitialized memory,
+    // then assume_init since all fields are plain integers with no invalid bit patterns.
+    unsafe {
+        core::ptr::copy_nonoverlapping(buf.as_ptr(), inode.as_mut_ptr().cast::<u8>(), inode_bytes);
+        inode.assume_init()
+    }
+}
+
+#[allow(clippy::cast_possible_truncation)]
+pub async fn read_inode_data(dev: usize, sb: &Ext2Superblock, inode: &Ext2Inode) -> Vec<u8> {
+    let file_size = inode.i_size as usize;
+    if file_size == 0 {
+        return Vec::new();
+    }
+
+    let block_size = sb.block_size();
+    let mut data = Vec::with_capacity(file_size);
+    let mut remaining = file_size;
+
+    // Direct blocks
+    for i in 0..EXT2_NDIR_BLOCKS {
+        if remaining == 0 {
+            break;
+        }
+        if inode.i_block[i] == 0 {
+            break;
+        }
+        read_block_data(dev, inode.i_block[i], block_size, remaining, &mut data).await;
+        remaining = file_size.saturating_sub(data.len());
+    }
+
+    // Indirect block
+    if remaining > 0 && inode.i_block[EXT2_IND_BLOCK] != 0 {
+        read_indirect(
+            dev,
+            inode.i_block[EXT2_IND_BLOCK],
+            block_size,
+            file_size,
+            &mut data,
+        )
+        .await;
+        remaining = file_size.saturating_sub(data.len());
+    }
+
+    // Doubly indirect block
+    if remaining > 0 && inode.i_block[EXT2_DIND_BLOCK] != 0 {
+        read_doubly_indirect(
+            dev,
+            inode.i_block[EXT2_DIND_BLOCK],
+            block_size,
+            file_size,
+            &mut data,
+        )
+        .await;
+        remaining = file_size.saturating_sub(data.len());
+    }
+
+    // Triply indirect block
+    if remaining > 0 && inode.i_block[EXT2_TIND_BLOCK] != 0 {
+        read_triply_indirect(
+            dev,
+            inode.i_block[EXT2_TIND_BLOCK],
+            block_size,
+            file_size,
+            &mut data,
+        )
+        .await;
+    }
+
+    data.truncate(file_size);
+    data
+}
+
+#[allow(clippy::cast_possible_truncation)]
+async fn read_block_data(
+    dev: usize,
+    block_num: u32,
+    block_size: usize,
+    remaining: usize,
+    data: &mut Vec<u8>,
+) {
+    let offset = block_num as usize * block_size;
+    let to_read = remaining.min(block_size);
+    let start = data.len();
+    data.resize(start + to_read, 0);
+    let n = block::read(dev, offset, &mut data[start..start + to_read])
+        .await
+        .expect("block read must succeed");
+    assert!(n == to_read, "short block read");
+}
+
+async fn read_block_pointers(dev: usize, block_num: u32, block_size: usize) -> Vec<u32> {
+    let mut buf = vec![0u8; block_size];
+    #[allow(clippy::cast_possible_truncation)]
+    let offset = block_num as usize * block_size;
+    let n = block::read(dev, offset, &mut buf)
+        .await
+        .expect("indirect block read must succeed");
+    assert!(n == block_size, "short indirect block read");
+
+    let ptrs_per_block = block_size / 4;
+    let mut pointers = Vec::with_capacity(ptrs_per_block);
+    for i in 0..ptrs_per_block {
+        pointers.push(*buf[i * 4..].interpret_as::<u32>());
+    }
+    pointers
+}
+
+async fn read_indirect(
+    dev: usize,
+    indirect_block: u32,
+    block_size: usize,
+    file_size: usize,
+    data: &mut Vec<u8>,
+) {
+    let pointers = read_block_pointers(dev, indirect_block, block_size).await;
+    for &ptr in &pointers {
+        if ptr == 0 || data.len() >= file_size {
+            break;
+        }
+        let remaining = file_size - data.len();
+        read_block_data(dev, ptr, block_size, remaining, data).await;
+    }
+}
+
+async fn read_doubly_indirect(
+    dev: usize,
+    dind_block: u32,
+    block_size: usize,
+    file_size: usize,
+    data: &mut Vec<u8>,
+) {
+    let l1_pointers = read_block_pointers(dev, dind_block, block_size).await;
+    for &l1_ptr in &l1_pointers {
+        if l1_ptr == 0 || data.len() >= file_size {
+            break;
+        }
+        read_indirect(dev, l1_ptr, block_size, file_size, data).await;
+    }
+}
+
+async fn read_triply_indirect(
+    dev: usize,
+    tind_block: u32,
+    block_size: usize,
+    file_size: usize,
+    data: &mut Vec<u8>,
+) {
+    let l1_pointers = read_block_pointers(dev, tind_block, block_size).await;
+    for &l1_ptr in &l1_pointers {
+        if l1_ptr == 0 || data.len() >= file_size {
+            break;
+        }
+        read_doubly_indirect(dev, l1_ptr, block_size, file_size, data).await;
+    }
+}

--- a/kernel/src/fs/ext2/mod.rs
+++ b/kernel/src/fs/ext2/mod.rs
@@ -1,0 +1,158 @@
+mod dir;
+mod file;
+mod inode;
+pub mod structures;
+
+use alloc::{boxed::Box, collections::BTreeMap, string::String, vec};
+
+use crate::{
+    drivers::virtio::block,
+    fs::vfs::{self, VfsNodeRef, alloc_ino},
+    info,
+    klibc::util::BufferExtension,
+};
+
+use dir::Ext2Dir;
+use file::Ext2File;
+use inode::{read_inode, read_inode_data};
+use structures::{
+    EXT2_FT_DIR, EXT2_FT_REG_FILE, EXT2_MAGIC, EXT2_ROOT_INODE, Ext2BlockGroupDescriptor,
+    Ext2DirEntry, Ext2Superblock,
+};
+
+pub async fn mount_ext2(dev: usize) {
+    info!("ext2: mounting block device {}", dev);
+
+    let sb = read_superblock(dev).await;
+    assert!(
+        sb.s_magic == EXT2_MAGIC,
+        "ext2: bad magic 0x{:04X}",
+        sb.s_magic
+    );
+
+    let block_size = sb.block_size();
+    info!(
+        "ext2: block_size={}, inodes={}, blocks={}",
+        block_size, sb.s_inodes_count, sb.s_blocks_count
+    );
+
+    let bgds = read_block_group_descriptors(dev, &sb).await;
+
+    let root = build_tree(dev, &sb, &bgds, EXT2_ROOT_INODE).await;
+    vfs::mount("/mnt", root);
+    info!("ext2: mounted at /mnt");
+}
+
+#[allow(clippy::cast_possible_truncation)]
+async fn read_superblock(dev: usize) -> Ext2Superblock {
+    let sb_size = core::mem::size_of::<Ext2Superblock>();
+    let mut buf = vec![0u8; sb_size];
+    let n = block::read(dev, 1024, &mut buf)
+        .await
+        .expect("superblock read must succeed");
+    assert!(n == sb_size, "short superblock read");
+
+    let mut sb = core::mem::MaybeUninit::<Ext2Superblock>::uninit();
+    // SAFETY: All fields are plain integers; we copy the exact struct size.
+    unsafe {
+        core::ptr::copy_nonoverlapping(buf.as_ptr(), sb.as_mut_ptr().cast::<u8>(), sb_size);
+        sb.assume_init()
+    }
+}
+
+#[allow(clippy::cast_possible_truncation)]
+async fn read_block_group_descriptors(
+    dev: usize,
+    sb: &Ext2Superblock,
+) -> alloc::vec::Vec<Ext2BlockGroupDescriptor> {
+    let block_size = sb.block_size();
+    let num_groups = sb.num_block_groups() as usize;
+    let bgd_size = core::mem::size_of::<Ext2BlockGroupDescriptor>();
+    let total_size = num_groups * bgd_size;
+
+    // BGD table starts at the block after the superblock
+    let bgd_offset = if block_size == 1024 { 2048 } else { block_size };
+
+    let mut buf = vec![0u8; total_size];
+    let n = block::read(dev, bgd_offset, &mut buf)
+        .await
+        .expect("BGD read must succeed");
+    assert!(n == total_size, "short BGD read");
+
+    let mut bgds = alloc::vec::Vec::with_capacity(num_groups);
+    for i in 0..num_groups {
+        bgds.push(*buf[i * bgd_size..].interpret_as::<Ext2BlockGroupDescriptor>());
+    }
+    bgds
+}
+
+fn build_tree<'a>(
+    dev: usize,
+    sb: &'a Ext2Superblock,
+    bgds: &'a [Ext2BlockGroupDescriptor],
+    inode_number: u32,
+) -> core::pin::Pin<Box<dyn Future<Output = VfsNodeRef> + Send + 'a>> {
+    Box::pin(async move {
+        let ext2_inode = read_inode(dev, sb, bgds, inode_number).await;
+
+        if ext2_inode.is_dir() {
+            let dir_data = read_inode_data(dev, sb, &ext2_inode).await;
+            let entries = parse_dir_entries(&dir_data);
+
+            let mut children = BTreeMap::new();
+            for (name, child_ino, file_type) in entries {
+                let child: VfsNodeRef = if file_type == EXT2_FT_DIR {
+                    build_tree(dev, sb, bgds, child_ino).await
+                } else if file_type == EXT2_FT_REG_FILE {
+                    let child_inode = read_inode(dev, sb, bgds, child_ino).await;
+                    let data = read_inode_data(dev, sb, &child_inode).await;
+                    #[allow(clippy::cast_possible_truncation)]
+                    let file_size = child_inode.i_size as usize;
+                    Ext2File::new(alloc_ino(), data, file_size)
+                } else {
+                    continue;
+                };
+                children.insert(name, child);
+            }
+
+            Ext2Dir::new(alloc_ino(), children) as VfsNodeRef
+        } else if ext2_inode.is_regular() {
+            let data = read_inode_data(dev, sb, &ext2_inode).await;
+            #[allow(clippy::cast_possible_truncation)]
+            let file_size = ext2_inode.i_size as usize;
+            Ext2File::new(alloc_ino(), data, file_size) as VfsNodeRef
+        } else {
+            Ext2File::new(alloc_ino(), alloc::vec::Vec::new(), 0) as VfsNodeRef
+        }
+    })
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn parse_dir_entries(data: &[u8]) -> alloc::vec::Vec<(String, u32, u8)> {
+    let mut entries = alloc::vec::Vec::new();
+    let mut offset = 0;
+
+    while offset + core::mem::size_of::<Ext2DirEntry>() <= data.len() {
+        let entry: &Ext2DirEntry = data[offset..].interpret_as();
+        if entry.rec_len == 0 {
+            break;
+        }
+
+        if entry.inode != 0 {
+            let name_start = offset + core::mem::size_of::<Ext2DirEntry>();
+            let name_end = name_start + entry.name_len as usize;
+            if name_end <= data.len() {
+                let name = core::str::from_utf8(&data[name_start..name_end])
+                    .expect("ext2 dir entry name must be valid UTF-8");
+                // Skip . and .. to avoid cycles
+                if name != "." && name != ".." {
+                    entries.push((String::from(name), entry.inode, entry.file_type));
+                }
+            }
+        }
+
+        offset += entry.rec_len as usize;
+    }
+
+    entries
+}

--- a/kernel/src/fs/ext2/mod.rs
+++ b/kernel/src/fs/ext2/mod.rs
@@ -10,6 +10,7 @@ use crate::{
     fs::vfs::{self, VfsNodeRef, alloc_ino},
     info,
     klibc::util::BufferExtension,
+    warn,
 };
 
 use dir::Ext2Dir;
@@ -24,11 +25,13 @@ pub async fn mount_ext2(dev: usize) {
     info!("ext2: mounting block device {}", dev);
 
     let sb = read_superblock(dev).await;
-    assert!(
-        sb.s_magic == EXT2_MAGIC,
-        "ext2: bad magic 0x{:04X}",
-        sb.s_magic
-    );
+    if sb.s_magic != EXT2_MAGIC {
+        warn!(
+            "ext2: block device {} is not ext2 (magic 0x{:04X}), skipping",
+            dev, sb.s_magic
+        );
+        return;
+    }
 
     let block_size = sb.block_size();
     info!(

--- a/kernel/src/fs/ext2/structures.rs
+++ b/kernel/src/fs/ext2/structures.rs
@@ -1,0 +1,118 @@
+pub const EXT2_MAGIC: u16 = 0xEF53;
+pub const EXT2_ROOT_INODE: u32 = 2;
+
+pub const EXT2_FT_REG_FILE: u8 = 1;
+pub const EXT2_FT_DIR: u8 = 2;
+
+pub const S_IFMT: u16 = 0xF000;
+pub const S_IFDIR: u16 = 0x4000;
+pub const S_IFREG: u16 = 0x8000;
+
+pub const EXT2_NDIR_BLOCKS: usize = 12;
+pub const EXT2_IND_BLOCK: usize = 12;
+pub const EXT2_DIND_BLOCK: usize = 13;
+pub const EXT2_TIND_BLOCK: usize = 14;
+
+#[repr(C)]
+pub struct Ext2Superblock {
+    pub s_inodes_count: u32,
+    pub s_blocks_count: u32,
+    pub s_r_blocks_count: u32,
+    pub s_free_blocks_count: u32,
+    pub s_free_inodes_count: u32,
+    pub s_first_data_block: u32,
+    pub s_log_block_size: u32,
+    pub s_log_frag_size: u32,
+    pub s_blocks_per_group: u32,
+    pub s_frags_per_group: u32,
+    pub s_inodes_per_group: u32,
+    pub s_mtime: u32,
+    pub s_wtime: u32,
+    pub s_mnt_count: u16,
+    pub s_max_mnt_count: u16,
+    pub s_magic: u16,
+    pub s_state: u16,
+    pub s_errors: u16,
+    pub s_minor_rev_level: u16,
+    pub s_lastcheck: u32,
+    pub s_checkinterval: u32,
+    pub s_creator_os: u32,
+    pub s_rev_level: u32,
+    pub s_def_resuid: u16,
+    pub s_def_resgid: u16,
+    // EXT2_DYNAMIC_REV fields
+    pub s_first_ino: u32,
+    pub s_inode_size: u16,
+}
+
+impl Ext2Superblock {
+    pub fn block_size(&self) -> usize {
+        1024 << self.s_log_block_size
+    }
+
+    pub fn inode_size(&self) -> usize {
+        if self.s_rev_level == 0 {
+            128
+        } else {
+            self.s_inode_size as usize
+        }
+    }
+
+    pub fn num_block_groups(&self) -> u32 {
+        self.s_blocks_count.div_ceil(self.s_blocks_per_group)
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct Ext2BlockGroupDescriptor {
+    pub bg_block_bitmap: u32,
+    pub bg_inode_bitmap: u32,
+    pub bg_inode_table: u32,
+    pub bg_free_blocks_count: u16,
+    pub bg_free_inodes_count: u16,
+    pub bg_used_dirs_count: u16,
+    pub bg_pad: u16,
+    pub bg_reserved: [u32; 3],
+}
+
+#[repr(C)]
+pub struct Ext2Inode {
+    pub i_mode: u16,
+    pub i_uid: u16,
+    pub i_size: u32,
+    pub i_atime: u32,
+    pub i_ctime: u32,
+    pub i_mtime: u32,
+    pub i_dtime: u32,
+    pub i_gid: u16,
+    pub i_links_count: u16,
+    pub i_blocks: u32,
+    pub i_flags: u32,
+    pub i_osd1: u32,
+    pub i_block: [u32; 15],
+    pub i_generation: u32,
+    pub i_file_acl: u32,
+    pub i_dir_acl: u32,
+    pub i_faddr: u32,
+    pub i_osd2: [u8; 12],
+}
+
+impl Ext2Inode {
+    pub fn is_dir(&self) -> bool {
+        self.i_mode & S_IFMT == S_IFDIR
+    }
+
+    pub fn is_regular(&self) -> bool {
+        self.i_mode & S_IFMT == S_IFREG
+    }
+}
+
+#[repr(C)]
+pub struct Ext2DirEntry {
+    pub inode: u32,
+    pub rec_len: u16,
+    pub name_len: u8,
+    pub file_type: u8,
+    // name follows (variable length)
+}

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -1,4 +1,6 @@
 pub mod devfs;
+#[cfg(target_arch = "riscv64")]
+pub mod ext2;
 pub mod open_file;
 mod procfs;
 mod tmpfs;

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -193,6 +193,10 @@ extern "C" fn kernel_init(hart_id: usize, device_tree_pointer: *const ()) -> ! {
         plic::init_virtio_block_interrupt(plic_irq);
     }
 
+    if drivers::virtio::block::device_count() > 0 {
+        processes::kernel_tasks::spawn(fs::ext2::mount_ext2(0));
+    }
+
     if let Some(i) = pci_devices
         .iter()
         .position(drivers::virtio::rng::RngDevice::is_virtio_rng)

--- a/system-tests/src/tests/ext2.rs
+++ b/system-tests/src/tests/ext2.rs
@@ -1,0 +1,142 @@
+use std::path::Path;
+use std::process::Command;
+
+use crate::infra::qemu::{QemuInstance, QemuOptions};
+
+fn find_mkfs_ext2() -> Option<String> {
+    // Try PATH first
+    if Command::new("mkfs.ext2")
+        .arg("-V")
+        .output()
+        .is_ok_and(|o| o.status.success() || !o.stderr.is_empty())
+    {
+        return Some("mkfs.ext2".into());
+    }
+    // Try nix store paths
+    for entry in std::fs::read_dir("/nix/store").ok()? {
+        let entry = entry.ok()?;
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if name_str.contains("e2fsprogs") && name_str.ends_with("-bin") {
+            let candidate = entry.path().join("bin/mkfs.ext2");
+            if candidate.exists() {
+                return Some(candidate.to_string_lossy().into_owned());
+            }
+        }
+    }
+    None
+}
+
+fn create_ext2_image(path: &Path, files: &[(&str, &str)], dirs: &[&str]) {
+    let mkfs = find_mkfs_ext2().expect("mkfs.ext2 not found; install e2fsprogs");
+
+    let dir = tempfile::tempdir().expect("create tmpdir for ext2 root");
+    let root = dir.path();
+
+    for d in dirs {
+        std::fs::create_dir_all(root.join(d)).expect("create subdir");
+    }
+    for (name, content) in files {
+        let file_path = root.join(name);
+        if let Some(parent) = file_path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent");
+        }
+        std::fs::write(&file_path, content).expect("write file");
+    }
+
+    let output = Command::new(&mkfs)
+        .args(["-d", &root.to_string_lossy()])
+        .arg("-F")
+        .arg(path)
+        .arg("4096")
+        .output()
+        .expect("run mkfs.ext2");
+    assert!(
+        output.status.success(),
+        "mkfs.ext2 failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[tokio::test]
+async fn ext2_read_file() -> anyhow::Result<()> {
+    if find_mkfs_ext2().is_none() {
+        eprintln!("SKIP: mkfs.ext2 not found");
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let img = dir.path().join("ext2.img");
+    create_ext2_image(
+        &img,
+        &[
+            ("hello.txt", "Hello from ext2!"),
+            ("subdir/nested.txt", "Nested content"),
+        ],
+        &["subdir"],
+    );
+
+    let mut solaya = QemuInstance::start_with(QemuOptions::default().block_device(img)).await?;
+    let output = solaya.run_prog("ext2test").await?;
+
+    assert!(
+        output.contains("FILE:Hello from ext2!"),
+        "Expected file content, got: {}",
+        output
+    );
+    assert!(
+        output.contains("OK read_file"),
+        "Expected OK read_file, got: {}",
+        output
+    );
+    assert!(
+        output.contains("OK readdir"),
+        "Expected OK readdir, got: {}",
+        output
+    );
+    assert!(
+        output.contains("NESTED:Nested content"),
+        "Expected nested content, got: {}",
+        output
+    );
+    assert!(
+        output.contains("OK nested_read"),
+        "Expected OK nested_read, got: {}",
+        output
+    );
+    assert!(
+        output.contains("OK write_erofs"),
+        "Expected write EROFS, got: {}",
+        output
+    );
+    assert!(
+        output.contains("OK create_erofs"),
+        "Expected create EROFS, got: {}",
+        output
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn ext2_ls_mnt() -> anyhow::Result<()> {
+    if find_mkfs_ext2().is_none() {
+        eprintln!("SKIP: mkfs.ext2 not found");
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let img = dir.path().join("ext2.img");
+    create_ext2_image(&img, &[("testfile.txt", "abc")], &[]);
+
+    let mut solaya = QemuInstance::start_with(QemuOptions::default().block_device(img)).await?;
+    let output = solaya.run_prog("ls-test /mnt").await?;
+
+    assert!(
+        output.contains("testfile.txt"),
+        "Expected testfile.txt in ls output, got: {}",
+        output
+    );
+
+    Ok(())
+}

--- a/system-tests/src/tests/ext2.rs
+++ b/system-tests/src/tests/ext2.rs
@@ -1,35 +1,8 @@
-use std::path::Path;
-use std::process::Command;
+use std::{path::Path, process::Command};
 
 use crate::infra::qemu::{QemuInstance, QemuOptions};
 
-fn find_mkfs_ext2() -> Option<String> {
-    // Try PATH first
-    if Command::new("mkfs.ext2")
-        .arg("-V")
-        .output()
-        .is_ok_and(|o| o.status.success() || !o.stderr.is_empty())
-    {
-        return Some("mkfs.ext2".into());
-    }
-    // Try nix store paths
-    for entry in std::fs::read_dir("/nix/store").ok()? {
-        let entry = entry.ok()?;
-        let name = entry.file_name();
-        let name_str = name.to_string_lossy();
-        if name_str.contains("e2fsprogs") && name_str.ends_with("-bin") {
-            let candidate = entry.path().join("bin/mkfs.ext2");
-            if candidate.exists() {
-                return Some(candidate.to_string_lossy().into_owned());
-            }
-        }
-    }
-    None
-}
-
 fn create_ext2_image(path: &Path, files: &[(&str, &str)], dirs: &[&str]) {
-    let mkfs = find_mkfs_ext2().expect("mkfs.ext2 not found; install e2fsprogs");
-
     let dir = tempfile::tempdir().expect("create tmpdir for ext2 root");
     let root = dir.path();
 
@@ -44,13 +17,13 @@ fn create_ext2_image(path: &Path, files: &[(&str, &str)], dirs: &[&str]) {
         std::fs::write(&file_path, content).expect("write file");
     }
 
-    let output = Command::new(&mkfs)
+    let output = Command::new("mkfs.ext2")
         .args(["-d", &root.to_string_lossy()])
         .arg("-F")
         .arg(path)
         .arg("4096")
         .output()
-        .expect("run mkfs.ext2");
+        .expect("run mkfs.ext2 (install e2fsprogs or enter nix shell)");
     assert!(
         output.status.success(),
         "mkfs.ext2 failed: {}",
@@ -60,11 +33,6 @@ fn create_ext2_image(path: &Path, files: &[(&str, &str)], dirs: &[&str]) {
 
 #[tokio::test]
 async fn ext2_read_file() -> anyhow::Result<()> {
-    if find_mkfs_ext2().is_none() {
-        eprintln!("SKIP: mkfs.ext2 not found");
-        return Ok(());
-    }
-
     let dir = tempfile::tempdir()?;
     let img = dir.path().join("ext2.img");
     create_ext2_image(
@@ -120,11 +88,6 @@ async fn ext2_read_file() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn ext2_ls_mnt() -> anyhow::Result<()> {
-    if find_mkfs_ext2().is_none() {
-        eprintln!("SKIP: mkfs.ext2 not found");
-        return Ok(());
-    }
-
     let dir = tempfile::tempdir()?;
     let img = dir.path().join("ext2.img");
     create_ext2_image(&img, &[("testfile.txt", "abc")], &[]);

--- a/system-tests/src/tests/mod.rs
+++ b/system-tests/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod basics;
 mod block;
 mod connect4;
+mod ext2;
 mod coreutils;
 mod fork;
 mod job_control;

--- a/userspace/src/bin/ext2test.rs
+++ b/userspace/src/bin/ext2test.rs
@@ -1,0 +1,45 @@
+fn main() {
+    // Test 1: Read a file from the ext2 mount
+    match std::fs::read_to_string("/mnt/hello.txt") {
+        Ok(content) => {
+            print!("FILE:{}", content);
+            println!("OK read_file");
+        }
+        Err(e) => println!("ERR read_file: {e}"),
+    }
+
+    // Test 2: List directory entries
+    match std::fs::read_dir("/mnt") {
+        Ok(entries) => {
+            for entry in entries {
+                match entry {
+                    Ok(e) => println!("DIR:{}", e.file_name().to_string_lossy()),
+                    Err(e) => println!("ERR entry: {e}"),
+                }
+            }
+            println!("OK readdir");
+        }
+        Err(e) => println!("ERR readdir: {e}"),
+    }
+
+    // Test 3: Read a nested file
+    match std::fs::read_to_string("/mnt/subdir/nested.txt") {
+        Ok(content) => {
+            print!("NESTED:{}", content);
+            println!("OK nested_read");
+        }
+        Err(e) => println!("ERR nested_read: {e}"),
+    }
+
+    // Test 4: Attempt to write (should fail with EROFS)
+    match std::fs::write("/mnt/hello.txt", b"nope") {
+        Ok(()) => println!("ERR write_should_fail"),
+        Err(_) => println!("OK write_erofs"),
+    }
+
+    // Test 5: Attempt to create file (should fail with EROFS)
+    match std::fs::File::create("/mnt/newfile.txt") {
+        Ok(_) => println!("ERR create_should_fail"),
+        Err(_) => println!("OK create_erofs"),
+    }
+}


### PR DESCRIPTION
## Summary
- Implements a read-only ext2 filesystem driver that mounts from virtio-blk devices
- Full tree pre-caching at mount time: reads all metadata + file contents into memory during an async kernel task, then all VfsNode operations are purely synchronous
- Supports direct, indirect, doubly-indirect, and triply-indirect block pointers
- Gracefully skips non-ext2 block devices

## New files
- `kernel/src/fs/ext2/` — ext2 module (mod.rs, structures.rs, inode.rs, dir.rs, file.rs)
- `userspace/src/bin/ext2test.rs` — Userspace test program
- `system-tests/src/tests/ext2.rs` — System tests using mkfs.ext2

## Key design
- Mount runs as async kernel task (`kernel_tasks::spawn`), reads everything eagerly
- After construction, Ext2Dir/Ext2File are immutable (no Spinlock needed)
- Returns EROFS for all write operations
- Mounts at `/mnt` from first block device

## Test plan
- [x] `ext2_read_file` — Creates ext2 image with test files, verifies read content
- [x] `ext2_ls_mnt` — Verifies directory listing on ext2 mount
- [x] All 55 existing system tests pass
- [x] Stress tested 10x — 8/10 passed (2 failures from pre-existing flaky `should_not_exit_shell`, unrelated to ext2)
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)