### PR TITLE
feat: bochs-display framebuffer driver + clock_gettime fix

### DIFF
--- a/kernel/src/drivers/bochs_display.rs
+++ b/kernel/src/drivers/bochs_display.rs
@@ -1,0 +1,69 @@
+use crate::{info, klibc::MMIO, pci::PCIDevice};
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+const VBE_DISPI_INDEX_XRES: u16 = 1;
+const VBE_DISPI_INDEX_YRES: u16 = 2;
+const VBE_DISPI_INDEX_BPP: u16 = 3;
+const VBE_DISPI_INDEX_ENABLE: u16 = 4;
+
+const VBE_DISPI_ENABLED: u16 = 0x01;
+const VBE_DISPI_LFB_ENABLED: u16 = 0x40;
+
+const BOCHS_VENDOR_ID: u16 = 0x1234;
+const BOCHS_DEVICE_ID: u16 = 0x1111;
+
+pub const FB_WIDTH: usize = 640;
+pub const FB_HEIGHT: usize = 480;
+pub const FB_BPP: usize = 32;
+pub const FB_STRIDE: usize = FB_WIDTH * (FB_BPP / 8);
+pub const FB_SIZE: usize = FB_STRIDE * FB_HEIGHT;
+
+static FB_BASE: AtomicUsize = AtomicUsize::new(0);
+
+pub fn fb_base() -> usize {
+    FB_BASE.load(Ordering::Relaxed)
+}
+
+pub fn is_bochs_display(device: &PCIDevice) -> bool {
+    let cs = device.configuration_space();
+    cs.vendor_id().read() == BOCHS_VENDOR_ID && cs.device_id().read() == BOCHS_DEVICE_ID
+}
+
+fn write_vbe_reg(dispi_base: usize, index: u16, value: u16) {
+    #[allow(clippy::cast_possible_truncation)]
+    let offset = index as usize * 2;
+    let mut reg: MMIO<u16> = MMIO::new(dispi_base + offset);
+    reg.write(value);
+}
+
+#[allow(clippy::cast_possible_truncation)]
+pub fn initialize(mut pci_device: PCIDevice) {
+    let bar0 = pci_device.get_or_initialize_bar(0);
+    let bar2 = pci_device.get_or_initialize_bar(2);
+
+    let fb_addr = bar0.cpu_address.as_usize();
+    let dispi_base = bar2.cpu_address.as_usize() + 0x500;
+
+    write_vbe_reg(dispi_base, VBE_DISPI_INDEX_ENABLE, 0);
+    write_vbe_reg(dispi_base, VBE_DISPI_INDEX_XRES, FB_WIDTH as u16);
+    write_vbe_reg(dispi_base, VBE_DISPI_INDEX_YRES, FB_HEIGHT as u16);
+    write_vbe_reg(dispi_base, VBE_DISPI_INDEX_BPP, FB_BPP as u16);
+    write_vbe_reg(
+        dispi_base,
+        VBE_DISPI_INDEX_ENABLE,
+        VBE_DISPI_ENABLED | VBE_DISPI_LFB_ENABLED,
+    );
+
+    pci_device
+        .configuration_space_mut()
+        .set_command_register_bits(
+            crate::pci::command_register::MEMORY_SPACE | crate::pci::command_register::BUS_MASTER,
+        );
+
+    FB_BASE.store(fb_addr, Ordering::Relaxed);
+
+    info!(
+        "bochs-display: framebuffer at {:#x}, {}x{}x{}",
+        fb_addr, FB_WIDTH, FB_HEIGHT, FB_BPP
+    );
+}

--- a/kernel/src/drivers/mod.rs
+++ b/kernel/src/drivers/mod.rs
@@ -1,1 +1,2 @@
+pub mod bochs_display;
 pub mod virtio;

--- a/kernel/src/fs/devfs.rs
+++ b/kernel/src/fs/devfs.rs
@@ -2,9 +2,12 @@ use alloc::{collections::BTreeMap, string::String, sync::Arc, vec::Vec};
 use headers::errno::Errno;
 
 use crate::{
-    drivers::virtio::{block, rng},
+    drivers::{
+        bochs_display,
+        virtio::{block, rng},
+    },
     io::tty_device::{TtyDevice, console_tty},
-    klibc::Spinlock,
+    klibc::{MMIO, Spinlock},
 };
 
 use super::vfs::{DirEntry, NodeType, VfsNode, VfsNodeRef, alloc_ino};
@@ -242,6 +245,73 @@ pub fn register_random_device() {
         .clone()
         .expect("devfs must be initialized before registering devices");
     dir.entries.lock().insert(String::from("random"), node);
+}
+
+struct DevFramebuffer {
+    ino: u64,
+}
+
+impl VfsNode for DevFramebuffer {
+    fn node_type(&self) -> NodeType {
+        NodeType::File
+    }
+
+    fn ino(&self) -> u64 {
+        self.ino
+    }
+
+    fn size(&self) -> usize {
+        bochs_display::FB_SIZE
+    }
+
+    fn read(&self, offset: usize, buf: &mut [u8]) -> Result<usize, Errno> {
+        let base = bochs_display::fb_base();
+        if base == 0 {
+            return Err(Errno::ENODEV);
+        }
+        let end = offset.saturating_add(buf.len()).min(bochs_display::FB_SIZE);
+        if offset >= end {
+            return Ok(0);
+        }
+        let len = end - offset;
+        for (i, byte) in buf[..len].iter_mut().enumerate() {
+            let mmio: MMIO<u8> = MMIO::new(base + offset + i);
+            *byte = mmio.read();
+        }
+        Ok(len)
+    }
+
+    fn write(&self, offset: usize, data: &[u8]) -> Result<usize, Errno> {
+        let base = bochs_display::fb_base();
+        if base == 0 {
+            return Err(Errno::ENODEV);
+        }
+        let end = offset
+            .saturating_add(data.len())
+            .min(bochs_display::FB_SIZE);
+        if offset >= end {
+            return Ok(0);
+        }
+        let len = end - offset;
+        for (i, &byte) in data[..len].iter().enumerate() {
+            let mut mmio: MMIO<u8> = MMIO::new(base + offset + i);
+            mmio.write(byte);
+        }
+        Ok(len)
+    }
+
+    fn truncate(&self) -> Result<(), Errno> {
+        Ok(())
+    }
+}
+
+pub fn register_framebuffer_device() {
+    let node: VfsNodeRef = Arc::new(DevFramebuffer { ino: alloc_ino() });
+    let dir = DEVFS
+        .lock()
+        .clone()
+        .expect("devfs must be initialized before registering devices");
+    dir.entries.lock().insert(String::from("fb0"), node);
 }
 
 pub fn register_block_device(index: usize) {

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -195,6 +195,15 @@ extern "C" fn kernel_init(hart_id: usize, device_tree_pointer: *const ()) -> ! {
 
     if let Some(i) = pci_devices
         .iter()
+        .position(drivers::bochs_display::is_bochs_display)
+    {
+        let device = pci_devices.swap_remove(i);
+        drivers::bochs_display::initialize(device);
+        fs::devfs::register_framebuffer_device();
+    }
+
+    if let Some(i) = pci_devices
+        .iter()
         .position(drivers::virtio::rng::RngDevice::is_virtio_rng)
     {
         let device = pci_devices.swap_remove(i);

--- a/kernel/src/pci/mod.rs
+++ b/kernel/src/pci/mod.rs
@@ -183,10 +183,8 @@ impl PCIDevice {
 
         let original_bar_value = configuration_space.bar(index);
         assert!(original_bar_value & 0x1 == 0, "Bar must be memory mapped");
-        assert!(
-            (original_bar_value & 0b110) >> 1 == 0x2,
-            "Bar must be 64-bit wide"
-        );
+        let bar_type = (original_bar_value & 0b110) >> 1;
+        let is_64bit = bar_type == 0x2;
 
         // Determine size of bar
         configuration_space.write_bar(index, 0xffffffff);
@@ -196,7 +194,7 @@ impl PCIDevice {
         // Invert the value and add 1 to get the size (because the bits that are not set are zero because of alignment)
         let size = !(bar_value & !0b1111) + 1;
 
-        debug!("Bar {} size: {:#x}", index, size);
+        debug!("Bar {} size: {:#x} 64bit={}", index, size, is_64bit);
 
         let space = pci::PCI_ALLOCATOR_64_BIT
             .lock()
@@ -207,10 +205,12 @@ impl PCIDevice {
             index,
             u32::try_from(space.pci_address.as_usize() & 0xFFFF_FFFF).expect("masked to 32 bits"),
         );
-        configuration_space.write_bar(
-            index + 1,
-            u32::try_from(space.pci_address.as_usize() >> 32).expect("high 32 bits fit in u32"),
-        );
+        if is_64bit {
+            configuration_space.write_bar(
+                index + 1,
+                u32::try_from(space.pci_address.as_usize() >> 32).expect("high 32 bits fit in u32"),
+            );
+        }
 
         configuration_space.set_command_register_bits(command_register::MEMORY_SPACE);
 
@@ -241,7 +241,9 @@ pub fn enumerate_devices(pci_information: &PCIInformation) -> Vec<PCIDevice> {
                 if let Some(device) = maybe_device {
                     let vendor_id = device.configuration_space.vendor_id().read();
                     let device_id = device.configuration_space.device_id().read();
-                    let name = lookup(vendor_id, device_id).expect("PCI Device must be known.");
+                    let name = lookup(vendor_id, device_id).unwrap_or_else(|| {
+                        alloc::format!("Unknown device {vendor_id:#06x}:{device_id:#06x}")
+                    });
                     info!(
                         "PCI Device {:#x}:{:#x} found at {} ({})",
                         vendor_id, device_id, address, name

--- a/kernel/src/pci/pci.ids
+++ b/kernel/src/pci/pci.ids
@@ -16756,6 +16756,8 @@
 	0d13  Desktop PCI L1/L3 Telephony
 1232  GPT Limited
 1233  Bus-Tech, Inc.
+1234  Technical Concepts Ltd.
+	1111  Bochs/QEMU VGA/Bochs Display
 # nee Risq Modular Systems, Inc.
 1235  SMART Modular Technologies
 1236  Sigma Designs Corporation

--- a/kernel/src/processes/timer.rs
+++ b/kernel/src/processes/timer.rs
@@ -90,6 +90,20 @@ pub fn wakeup_wakers() {
     }
 }
 
+#[allow(clippy::cast_possible_truncation)]
+pub fn current_time() -> timespec {
+    let clocks = arch::timer::get_current_clocks();
+    let clocks_per_nano = *CLOCKS_PER_NANO;
+    let clocks_per_second = clocks_per_nano * 1000 * 1000;
+    let secs = clocks / clocks_per_second;
+    let remaining_clocks = clocks % clocks_per_second;
+    let nsecs = remaining_clocks / clocks_per_nano;
+    timespec {
+        tv_sec: secs as i64,
+        tv_nsec: nsecs as i64,
+    }
+}
+
 pub fn set_timer(milliseconds: u64) {
     debug!("enabling timer {milliseconds} ms");
     let current = arch::timer::get_current_clocks();

--- a/kernel/src/syscalls/linux.rs
+++ b/kernel/src/syscalls/linux.rs
@@ -532,10 +532,7 @@ impl LinuxSyscalls for LinuxSyscallHandler {
         _clockid: c_int,
         tp: LinuxUserspaceArg<*mut timespec>,
     ) -> Result<isize, Errno> {
-        tp.write_slice(&[timespec {
-            tv_sec: 0,
-            tv_nsec: 0,
-        }])?;
+        tp.write_slice(&[crate::processes::timer::current_time()])?;
         Ok(0)
     }
 

--- a/qemu-infra/src/qemu.rs
+++ b/qemu-infra/src/qemu.rs
@@ -37,6 +37,7 @@ pub struct QemuOptions {
     use_smp: bool,
     enable_gdb: bool,
     block_device: Option<PathBuf>,
+    framebuffer: bool,
 }
 
 impl Default for QemuOptions {
@@ -47,6 +48,7 @@ impl Default for QemuOptions {
             use_smp: true,
             enable_gdb,
             block_device: None,
+            framebuffer: false,
         }
     }
 }
@@ -68,6 +70,10 @@ impl QemuOptions {
         self.block_device = Some(path);
         self
     }
+    pub fn framebuffer(mut self, value: bool) -> Self {
+        self.framebuffer = value;
+        self
+    }
 
     fn apply(self, command: &mut Command) -> Option<u16> {
         let mut network_port = None;
@@ -78,6 +84,9 @@ impl QemuOptions {
         }
         if let Some(block_path) = &self.block_device {
             command.args(["--block", &block_path.to_string_lossy()]);
+        }
+        if self.framebuffer {
+            command.arg("--fb");
         }
         if self.use_smp {
             command.arg("--smp");

--- a/qemu_wrapper.sh
+++ b/qemu_wrapper.sh
@@ -21,6 +21,10 @@ while [[ $# -gt 0 ]]; do
             QEMU_CMD+=" -object filter-dump,id=f1,netdev=netdev1,file=network.pcap "
             shift
             ;;
+        --fb)
+            QEMU_CMD+=" -device bochs-display"
+            shift
+            ;;
         --gdb)
             shift
             if [[ "$1" =~ ^[0-9]+$ ]]; then
@@ -36,6 +40,7 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Options:"
             echo "  --block FILE   Attach a raw disk image as virtio-blk device"
+            echo "  --fb           Attach bochs-display framebuffer device"
             echo "  --gdb [PORT]   Enable GDB server (default: dynamic port)"
             echo "  --log          Log qemu events to /tmp/solaya.log"
             echo "  --capture      Capture network traffic into network.pcap"

--- a/system-tests/src/tests/clocktest.rs
+++ b/system-tests/src/tests/clocktest.rs
@@ -1,0 +1,18 @@
+use crate::infra::qemu::QemuInstance;
+
+#[tokio::test]
+async fn clock_gettime_returns_nonzero() -> anyhow::Result<()> {
+    let mut solaya = QemuInstance::start().await?;
+    let output = solaya.run_prog("clocktest").await?;
+    assert!(
+        output.contains("clock OK"),
+        "clock_gettime failed: {}",
+        output
+    );
+    assert!(
+        output.contains("clock progression OK"),
+        "clock not progressing: {}",
+        output
+    );
+    Ok(())
+}

--- a/system-tests/src/tests/framebuffer.rs
+++ b/system-tests/src/tests/framebuffer.rs
@@ -1,0 +1,14 @@
+use crate::infra::qemu::{QemuInstance, QemuOptions};
+
+#[tokio::test]
+async fn framebuffer_device_exists() -> anyhow::Result<()> {
+    let mut solaya =
+        QemuInstance::start_with(QemuOptions::default().framebuffer(true)).await?;
+    let output = solaya.run_prog("fbtest").await?;
+    assert!(
+        output.contains("fb write OK"),
+        "framebuffer test failed: {}",
+        output
+    );
+    Ok(())
+}

--- a/system-tests/src/tests/mod.rs
+++ b/system-tests/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod basics;
 mod block;
+mod clocktest;
 mod connect4;
 mod coreutils;
 mod fork;

--- a/system-tests/src/tests/mod.rs
+++ b/system-tests/src/tests/mod.rs
@@ -4,6 +4,7 @@ mod clocktest;
 mod connect4;
 mod coreutils;
 mod fork;
+mod framebuffer;
 mod job_control;
 mod mutex;
 mod net;

--- a/userspace/src/bin/clocktest.rs
+++ b/userspace/src/bin/clocktest.rs
@@ -1,0 +1,16 @@
+use std::time::Instant;
+
+fn main() {
+    let start = Instant::now();
+    let elapsed = start.elapsed();
+    println!("clock OK: {:?}", elapsed);
+
+    // Busy-wait a bit to verify clock progresses
+    let start2 = Instant::now();
+    for _ in 0..100_000 {
+        core::hint::black_box(0);
+    }
+    let elapsed2 = start2.elapsed();
+    assert!(elapsed2 > std::time::Duration::ZERO);
+    println!("clock progression OK");
+}

--- a/userspace/src/bin/fbtest.rs
+++ b/userspace/src/bin/fbtest.rs
@@ -1,0 +1,12 @@
+use std::{fs::OpenOptions, io::Write};
+
+fn main() {
+    let mut fb = OpenOptions::new()
+        .write(true)
+        .open("/dev/fb0")
+        .expect("open fb0");
+    // Write a red pixel at position (0,0): XRGB8888 format
+    let pixel: [u8; 4] = [0, 0, 0xFF, 0];
+    fb.write_all(&pixel).expect("write pixel");
+    println!("fb write OK");
+}


### PR DESCRIPTION
## Summary
- Fixes `clock_gettime` to return real time from the RISC-V timer (was returning hardcoded zeros)
- Implements bochs-display PCI framebuffer driver with `/dev/fb0` device node
- Adds `--fb` QEMU flag and `QemuOptions::framebuffer()` for system tests

## Changes

### clock_gettime fix
- Added `current_time()` to `kernel/src/processes/timer.rs` using `get_current_clocks()` and `CLOCKS_PER_NANO`
- Updated `clock_gettime` syscall to call `timer::current_time()`

### Framebuffer driver
- `kernel/src/drivers/bochs_display.rs` — PCI driver: BAR init, VBE DISPI mode setting (640x480x32 XRGB8888)
- `kernel/src/fs/devfs.rs` — DevFramebuffer VfsNode with MMIO read/write to framebuffer memory
- `kernel/src/pci/mod.rs` — Handle unknown PCI devices gracefully + support 32-bit BARs (bochs-display uses 32-bit)
- `qemu_wrapper.sh` / `qemu-infra/src/qemu.rs` — `--fb` flag support

## Test plan
- [x] `clock_gettime_returns_nonzero` — Verifies clock reads non-zero and progresses
- [x] `framebuffer_device_exists` — Boots with `--fb`, writes pixel to `/dev/fb0`
- [x] All 55 system tests pass
- [x] Stress tested 10x — 10/10 passed, zero failures
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)