### PR TITLE
build: gate shell scripts through shellcheck in pre-commit + CI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-repo_root=$(git rev-parse --show-toplevel)
-
 # Format only staged Rust files to avoid touching unstaged work
 staged_rs_files=$(git diff --name-only --cached --diff-filter=d -- '*.rs')
 if [ -n "$staged_rs_files" ]; then

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,6 +11,20 @@ fi
 # Auto-fix what clippy can, fail on remaining warnings
 cargo clippy --fix --allow-dirty --allow-staged -- -D warnings
 
+# Shellcheck staged shell scripts. Hard-fail if shellcheck is missing so
+# this gate can't silently skip. Include edits to the hook itself so a
+# broken pre-commit can't sneak through.
+staged_sh_files=$(git diff --name-only --cached --diff-filter=d -- '*.sh' '.githooks/pre-commit')
+if [ -n "$staged_sh_files" ]; then
+    if ! command -v shellcheck >/dev/null 2>&1; then
+        echo "error: shellcheck not installed." >&2
+        echo "  Fedora:  sudo dnf install -y shellcheck" >&2
+        echo "  Ubuntu:  sudo apt-get install -y shellcheck" >&2
+        exit 1
+    fi
+    echo "$staged_sh_files" | xargs shellcheck
+fi
+
 # Rebuild INDEX.md and stage it if changed
 indxr -o INDEX.md
 if ! git diff --quiet -- INDEX.md; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
             flex bison bc \
             pkg-config \
             rsync \
+            shellcheck \
             e2fsprogs \
             qemu-system-misc qemu-system-data seabios ipxe-qemu
           # clang-18 / lld-18 / llvm-18 are the cross-toolchain; Ubuntu
@@ -123,6 +124,9 @@ jobs:
 
       - name: Clippy
         run: cmake --build "$BUILD_DIR" --target clippy
+
+      - name: Shellcheck
+        run: cmake --build "$BUILD_DIR" --target shellcheck
 
       - name: Unit tests
         run: cmake --build "$BUILD_DIR" --target test-unit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,7 +335,7 @@ Solaya is licensed under **MIT**. To keep it that way:
 
 **Commit automatically.** After completing a task, commit without waiting for user intervention. Before committing:
 - Remove any dead or unused code introduced by your changes
-- The pre-commit hook runs `cargo fmt` and `cargo clippy --fix` automatically; it will block the commit if clippy finds unfixable warnings.
+- The pre-commit hook runs `cargo fmt`, `cargo clippy --fix`, and `shellcheck` (on any staged `*.sh` or edits to `.githooks/pre-commit`) automatically; it blocks the commit if clippy has unfixable warnings or shellcheck reports any finding. Install `shellcheck` via `dnf install shellcheck` (Fedora) / `apt install shellcheck` (Ubuntu).
 
 **Commit incrementally.** Commit each small working step toward a larger goal. Include test code in commits. This enables incremental progress verification rather than large, hard-to-debug changesets.
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ sudo dnf install -y \
     flex bison bc \
     pkgconf-pkg-config \
     rsync \
-    ShellCheck \
+    shellcheck \
     e2fsprogs \
     just \
     qemu-system-riscv seavgabios-bin ipxe-roms-qemu

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ sudo apt-get install -y --no-install-recommends \
     flex bison bc \
     pkg-config \
     rsync \
+    shellcheck \
     e2fsprogs \
     qemu-system-misc qemu-system-data seabios ipxe-qemu
 # `just` is not packaged on 24.04; install via rustup's cargo:
@@ -116,6 +117,7 @@ sudo dnf install -y \
     flex bison bc \
     pkgconf-pkg-config \
     rsync \
+    ShellCheck \
     e2fsprogs \
     just \
     qemu-system-riscv seavgabios-bin ipxe-roms-qemu

--- a/cmake/build_compiler_rt_builtins.sh
+++ b/cmake/build_compiler_rt_builtins.sh
@@ -53,13 +53,13 @@ SKIP_RE='^(gcc_personality_v0|emutls|enable_execute_stack|eprintf|apple_versioni
 # linked into both -static and PIE final binaries.  -DVISIBILITY_HIDDEN
 # matches compiler-rt's upstream build (keeps internal helpers out of the
 # final executable's dynamic symbol table where applicable).
-CFLAGS="-fPIC -O2 -DVISIBILITY_HIDDEN -Wno-unused-command-line-argument"
+CFLAGS=(-fPIC -O2 -DVISIBILITY_HIDDEN -Wno-unused-command-line-argument)
 
 compile_one() {
     # $1 = src file (relative to $SRC), $2 = output .o path.  Uses `||` so
     # a single file's failure doesn't take down all the background jobs;
     # we audit the final object count against the source count afterwards.
-    "$CC" $CFLAGS -c "$SRC/$1" -o "$2" || {
+    "$CC" "${CFLAGS[@]}" -c "$SRC/$1" -o "$2" || {
         echo "FAIL: $1" >&2
         return 1
     }
@@ -86,7 +86,7 @@ for f in "$SRC"/*.c; do
     fi
     compiled=$((compiled + 1))
     throttle
-    ( compile_one "${f#$SRC/}" "$WORK/${base}.o" || echo "$base" >> "$FAILED_LIST" ) &
+    ( compile_one "${f#"$SRC"/}" "$WORK/${base}.o" || echo "$base" >> "$FAILED_LIST" ) &
 done
 
 echo "compiler-rt-builtins: compiling riscv builtins"
@@ -110,9 +110,11 @@ echo "compiler-rt-builtins: compiling crtbegin / crtend"
 compile_one "crtbegin.c" "$OUT/clang_rt.crtbegin.o"
 compile_one "crtend.c"   "$OUT/clang_rt.crtend.o"
 
-objcount=$(ls "$WORK" | grep -v '^\.' | wc -l)
+shopt -s nullglob
+objs=("$WORK"/*.o)
+objcount=${#objs[@]}
 echo "compiler-rt-builtins: archiving $objcount objects (of $compiled attempted) into libclang_rt.builtins.a"
 rm -f "$OUT/libclang_rt.builtins.a"
-"$AR" rcs "$OUT/libclang_rt.builtins.a" "$WORK"/*.o
+"$AR" rcs "$OUT/libclang_rt.builtins.a" "${objs[@]}"
 
 echo "compiler-rt-builtins: done ($OUT)"

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -113,9 +113,32 @@ add_custom_target(fmt-check
 )
 
 # -----------------------------------------------------------------------------
+# shellcheck: static analysis of every project-authored shell script.
+# Keep this list in sync with the pre-commit hook. Third-party scripts
+# under .toolchain/ and build/ are gitignored and not our code.
+# -----------------------------------------------------------------------------
+set(SOLAYA_SHELL_SCRIPTS
+    ${CMAKE_SOURCE_DIR}/.githooks/pre-commit
+    ${CMAKE_SOURCE_DIR}/cmake/build_compiler_rt_builtins.sh
+    ${CMAKE_SOURCE_DIR}/qemu_wrapper.sh
+    ${CMAKE_SOURCE_DIR}/scripts/attach.sh
+    ${CMAKE_SOURCE_DIR}/scripts/debug.sh
+    ${CMAKE_SOURCE_DIR}/scripts/picocom.sh
+    ${CMAKE_SOURCE_DIR}/scripts/reboot-hw.sh
+    ${CMAKE_SOURCE_DIR}/scripts/tftp-deploy.sh
+)
+add_custom_target(shellcheck
+    COMMAND shellcheck ${SOLAYA_SHELL_SCRIPTS}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    USES_TERMINAL
+    VERBATIM
+    COMMENT "shellcheck across every project-authored shell script"
+)
+
+# -----------------------------------------------------------------------------
 # ci: the full pre-merge gate.
 # -----------------------------------------------------------------------------
 add_custom_target(ci
-    DEPENDS fmt-check clippy test-unit miri test-system
-    COMMENT "All CI checks (fmt, clippy, unit, miri, system)"
+    DEPENDS fmt-check clippy shellcheck test-unit miri test-system
+    COMMENT "All CI checks (fmt, clippy, shellcheck, unit, miri, system)"
 )

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -114,19 +114,25 @@ add_custom_target(fmt-check
 
 # -----------------------------------------------------------------------------
 # shellcheck: static analysis of every project-authored shell script.
-# Keep this list in sync with the pre-commit hook. Third-party scripts
-# under .toolchain/ and build/ are gitignored and not our code.
+# The script list is driven by `git ls-files` so the pre-commit hook's glob
+# (`*.sh` + `.githooks/pre-commit`) and this CMake target can't drift — a new
+# *.sh commit is gated automatically, without a tests.cmake edit. Third-party
+# scripts under .toolchain/ and build/ are excluded by virtue of being
+# gitignored. Snapshot taken at configure time; `cmake` auto-reruns when
+# tests.cmake changes, and CI always re-configures from a fresh checkout, so
+# both gates see the same list as the hook.
 # -----------------------------------------------------------------------------
-set(SOLAYA_SHELL_SCRIPTS
-    ${CMAKE_SOURCE_DIR}/.githooks/pre-commit
-    ${CMAKE_SOURCE_DIR}/cmake/build_compiler_rt_builtins.sh
-    ${CMAKE_SOURCE_DIR}/qemu_wrapper.sh
-    ${CMAKE_SOURCE_DIR}/scripts/attach.sh
-    ${CMAKE_SOURCE_DIR}/scripts/debug.sh
-    ${CMAKE_SOURCE_DIR}/scripts/picocom.sh
-    ${CMAKE_SOURCE_DIR}/scripts/reboot-hw.sh
-    ${CMAKE_SOURCE_DIR}/scripts/tftp-deploy.sh
+execute_process(
+    COMMAND git -C ${CMAKE_SOURCE_DIR} ls-files "*.sh" ".githooks/pre-commit"
+    OUTPUT_VARIABLE _solaya_shell_scripts_raw
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE _solaya_shell_scripts_result
 )
+if(NOT _solaya_shell_scripts_result EQUAL 0)
+    message(FATAL_ERROR "git ls-files failed while discovering shell scripts (exit ${_solaya_shell_scripts_result})")
+endif()
+string(REPLACE "\n" ";" SOLAYA_SHELL_SCRIPTS "${_solaya_shell_scripts_raw}")
+list(TRANSFORM SOLAYA_SHELL_SCRIPTS PREPEND "${CMAKE_SOURCE_DIR}/")
 add_custom_target(shellcheck
     COMMAND shellcheck ${SOLAYA_SHELL_SCRIPTS}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}

--- a/justfile
+++ b/justfile
@@ -72,6 +72,9 @@ test-system *TEST:
 clippy:
     cmake --build {{BUILD_DIR}} --target clippy
 
+shellcheck:
+    cmake --build {{BUILD_DIR}} --target shellcheck
+
 miri:
     cmake --build {{BUILD_DIR}} --target miri
 


### PR DESCRIPTION
## Summary

- New `shellcheck` CMake target runs at default severity over every project-authored shell script (the pre-commit hook itself, `cmake/build_compiler_rt_builtins.sh`, `qemu_wrapper.sh`, and `scripts/*.sh`). Wired into the `ci` aggregate alongside `fmt-check` / `clippy` / `test-unit` / `miri` / `test-system`. `just shellcheck` is the passthrough recipe.
- Pre-commit hook now shellchecks any staged `*.sh` file plus edits to `.githooks/pre-commit`. Hard-fails with a `dnf`/`apt` install hint if the binary is missing, consistent with how the hook treats `cargo`, `rustfmt`, and `indxr`.
- CI workflow (`.github/workflows/ci.yml`) installs `shellcheck` via apt and runs the CMake target between Clippy and Unit tests.
- Fixed every finding shellcheck flagged on the current tree (5 total): dropped unused `repo_root` in the hook (SC2034); converted `CFLAGS` to an array (SC2086), quoted the `${f#"$SRC"/}` prefix-strip (SC2295), and replaced `ls "$WORK" | grep -v '^\.' | wc -l` with a nullglob over `*.o` (SC2010 + SC2126) in the compiler-rt bootstrap.
- README Ubuntu/Fedora prereq lists + CLAUDE.md's pre-commit paragraph updated to mention shellcheck.

## Test plan

- [x] `cmake --build build --target shellcheck` — clean on all 8 scripts.
- [x] `cmake --build build --target toolchain-all` after deleting `.toolchain/riscv64/rt` — rebuilt `libclang_rt.builtins.a` is byte-identical to the previous output (295,376 bytes, 156 objects, same crtbegin/crtend sizes), confirming the array-based rewrite of `build_compiler_rt_builtins.sh` preserves behaviour.
- [x] `just shellcheck` passthrough works.
- [ ] CI run on this PR passes the new Shellcheck step.
- [ ] End-to-end pre-commit exercise: stage a `.sh` with an introduced violation and confirm the hook blocks.
- [ ] Temporarily mask `shellcheck` on PATH, stage a `.sh`, confirm the hook fails with the install-hint message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)