### PR TITLE
review: add review-followup skill + dismiss/discuss markers

### DIFF
--- a/.claude/skills/review-followup/SKILL.md
+++ b/.claude/skills/review-followup/SKILL.md
@@ -61,9 +61,12 @@ job run yet?" Do **not** create one.
 
 ## Step 3 — Parse the body
 
-Split the body into sections by the headings (`### Must-fix`,
-`### Consider`, `### Noted`, `### Skipped`). Within each triaged
-section, extract every `- [ ]` / `- [x]` line and capture:
+Split the body into sections by **prefix-matching** the headings
+`### Must-fix`, `### Consider`, `### Noted`, `### Skipped`. The bot's
+template appends a parenthetical to each (e.g.
+`### Must-fix (correctness / safety / policy violations)`), so match
+on `startswith` rather than equality. Within each triaged section,
+extract every `- [ ]` / `- [x]` line and capture:
 
 - state marker (` ` or `x`)
 - the full line text (verbatim, no rephrasing), including any
@@ -122,37 +125,46 @@ Applies to both **dismiss** (flip `[ ]` → `[x]`, append
 replace `— _discuss: <note>_`).
 
 1. **Re-fetch the current body** by comment id — it may have changed
-   since step 2 if the bot re-ran. Use `mktemp` so concurrent
-   sessions don't clobber each other:
+   since step 2 if the bot re-ran. Capture the repo nwo once and
+   reuse it; use `mktemp` so concurrent sessions don't clobber each
+   other:
 
    ```bash
+   REPO_NWO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
    BODY_FILE=$(mktemp --suffix=.md)
    trap 'rm -f "$BODY_FILE"' EXIT
-   gh api "/repos/$(gh repo view --json nameWithOwner --jq .nameWithOwner)/issues/comments/<id>" \
-     --jq .body > "$BODY_FILE"
+   gh api "/repos/$REPO_NWO/issues/comments/<id>" --jq .body > "$BODY_FILE"
    ```
 
-2. Do an exact-text line replacement on the file — match the full
-   original line verbatim and replace with the new line:
+2. **Re-parse the freshly-fetched body** to find the line you're
+   about to flip. Do not reuse the line text captured at Step 3 — a
+   benign cosmetic edit by the bot would invalidate it. Locate the
+   item by its position in the parsed worklist (section + index, or
+   by a stable substring like the cited `path:LINE`) and use the
+   *current* line text as the match target.
+
+3. Do an exact-text line replacement on the file — match the full
+   current line verbatim and replace with the new line:
    - dismiss: `- [ ] <text>` → `- [x] <text> — _dismissed: <reason>_`
    - discuss (first time): `- [ ] <text>` → `- [ ] <text> — _discuss: <note>_`
    - discuss (replacing a prior discuss note):
      `- [ ] <text> — _discuss: <old>_` → `- [ ] <text> — _discuss: <new>_`
 
-   If the line can't be found verbatim (bot rewrote it on a
-   concurrent run), abort this flip and tell the user — do not guess.
+   If the line still can't be found (the finding itself was rewritten
+   or removed on a concurrent run), abort this flip and tell the user
+   — do not guess.
 
-3. PATCH the comment:
+4. PATCH the comment, reusing `$REPO_NWO`:
 
    ```bash
-   gh api -X PATCH "/repos/$(gh repo view --json nameWithOwner --jq .nameWithOwner)/issues/comments/<id>" \
+   gh api -X PATCH "/repos/$REPO_NWO/issues/comments/<id>" \
      -F body=@"$BODY_FILE"
    ```
 
    (`-F body=@file` reads the file as the body field — safer than
    `-f body="$(cat ...)"` which can blow up on shell-special chars.)
 
-4. Verify success by re-reading the comment body and confirming the
+5. Verify success by re-reading the comment body and confirming the
    new line is present with the correct marker and suffix.
 
 ## Step 6 — Session end

--- a/.claude/skills/review-followup/SKILL.md
+++ b/.claude/skills/review-followup/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: review-followup
+description: Triage the AI Architectural Review comment on the current PR — fix or dismiss each open finding interactively, commit per fix, push at end.
+---
+
+# Review-Followup
+
+You are driving the interactive fix-or-dismiss loop against the single
+**AI Architectural Review** comment posted by the review bot (see
+`.github/workflows/claude-code-review.yml` and
+`.github/ai-review-prompt.md`).
+
+## Ground rules
+
+- The review lives in **one** comment per PR, edited in place by the bot.
+- Each finding is a markdown task-list line that starts with `- [ ]`,
+  `- [x]`, or `- [D]`:
+  - `- [ ]` → open, needs triage.
+  - `- [x]` → maintainer-accepted / implemented. **Never modify.**
+  - `- [D]` → maintainer-dismissed (permanent won't-fix). **Never modify.**
+- Four sections exist, in this order: `Must-fix`, `Consider`, `Noted`,
+  `Skipped`. Only items in the first three are triaged; `Skipped` is
+  informational.
+- Line wording from the bot is authoritative — when flipping state,
+  preserve the original line verbatim and only change the marker and
+  append a suffix.
+
+## Step 1 — Locate the PR
+
+Run:
+
+```bash
+gh pr view --json number,url,headRefName
+```
+
+If this fails or returns no PR for the current branch, abort with a
+clear message ("no open PR for branch `<name>`; push the branch and
+open a PR first") and stop. Do **not** try to create one.
+
+Record the PR number as `$PR`.
+
+## Step 2 — Fetch the review comment
+
+```bash
+gh pr view "$PR" --json comments \
+  --jq '[.comments[] | select(.author.login == "github-actions[bot]"
+        and (.body | startswith("## AI Architectural Review")))] | last
+        | {id, body}'
+```
+
+Capture both `id` and `body`. If no such comment exists, abort with
+"no AI Architectural Review comment found on PR #$PR — has the review
+job run yet?" Do **not** create one.
+
+## Step 3 — Parse the body
+
+Split the body into sections by the headings (`### Must-fix`,
+`### Consider`, `### Noted`, `### Skipped`). Within each triaged
+section, extract every `- [ ]` / `- [x]` / `- [D]` line and capture:
+
+- state marker (` `, `x`, `D`)
+- the full line text (verbatim, no rephrasing)
+- any cited `path/to/file.rs:LINE` reference (best-effort regex)
+
+Build a worklist of only the `- [ ]` items. If the worklist is empty,
+tell the user "nothing to triage on PR #$PR" and stop — do not push,
+do not commit.
+
+## Step 4 — Triage loop
+
+For each open item, one at a time in section order (Must-fix first):
+
+1. Show the finding to the user along with the relevant code context.
+   If the finding cites `path/to/file.rs:LINE`, Read a window around
+   that line (roughly ±20 lines) so the user sees the code before
+   deciding.
+2. Ask the user: **fix** or **dismiss**?
+3. On **fix**:
+   - Plan the change, apply it with normal tools (Edit/Grep/etc.).
+   - Run any obviously-relevant check (e.g. `just clippy` for a lint
+     finding, `just test-unit` for a logic finding). Don't run the
+     full `just ci` per item — that's overkill.
+   - Create one commit for this fix. Commit message should be short
+     and reference the finding — e.g.
+     `review: fix scheduler race flagged in review`. The pre-commit
+     hook runs fmt + clippy + shellcheck; if it blocks, fix and
+     re-stage into a NEW commit (never `--amend`).
+4. On **dismiss**:
+   - Ask the user for a one-line reason.
+   - Flip this line from `- [ ]` to `- [D]` and append
+     ` — _dismissed: <reason>_`.
+   - Update the comment body on GitHub (see Step 5).
+
+Do **not** batch dismissals — apply each one to the GH comment as it
+happens, so a mid-session abort still leaves consistent state.
+
+## Step 5 — Editing the GH comment
+
+When flipping an item to `- [D]`:
+
+1. **Re-fetch the current body** by comment id — it may have changed
+   since step 2 if the bot re-ran:
+
+   ```bash
+   gh api /repos/{owner}/{repo}/issues/comments/<id> --jq .body > /tmp/review-body.md
+   ```
+
+   (Get `{owner}/{repo}` from `gh repo view --json nameWithOwner --jq .nameWithOwner`.)
+
+2. Do an exact-text line replacement on the file — match the full
+   original `- [ ] ...` line and replace with
+   `- [D] ... — _dismissed: <reason>_`. If the line can't be found
+   verbatim (bot rewrote it on a concurrent run), abort this
+   dismissal and tell the user — do not guess.
+
+3. PATCH the comment:
+
+   ```bash
+   gh api -X PATCH /repos/{owner}/{repo}/issues/comments/<id> \
+     -F body=@/tmp/review-body.md
+   ```
+
+   (`-F body=@file` reads the file as the body field — safer than
+   `-f body="$(cat ...)"` which can blow up on shell-special chars.)
+
+4. Verify success by re-reading the comment body and confirming the
+   `- [D]` line is present.
+
+## Step 6 — Session end
+
+Once the worklist is exhausted:
+
+1. `git push` the accumulated fix commits. If there were no fixes
+   (only dismissals), skip the push — dismissals live on GitHub, not
+   in git.
+2. Tell the user:
+   - How many items were fixed vs dismissed.
+   - That the review bot will re-run on push and may surface new
+     findings.
+   - To re-invoke `/review-followup` once the next review comment
+     lands.
+
+## Safety rails (do not break)
+
+- Never rewrite `- [x]` or `- [D]` lines — both are final.
+- Never post a second top-level PR comment.
+- Never `git push --force` from this skill.
+- If a dismissed item resurfaces as `- [ ]` on a later run, flag it
+  to the user ("this was dismissed before — the bot didn't honor it")
+  rather than silently re-dismissing. That's a review-prompt bug
+  worth surfacing.
+- If the user course-corrects mid-fix ("no, don't change that"),
+  revert the staged edits and return to triage of the next item.
+  Don't commit a half-baked fix.

--- a/.claude/skills/review-followup/SKILL.md
+++ b/.claude/skills/review-followup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: review-followup
-description: Triage the AI Architectural Review comment on the current PR — fix or dismiss each open finding interactively, commit per fix, push at end.
+description: Triage the AI Architectural Review comment on the current PR — fix, dismiss, or defer-for-discussion each open finding interactively, commit per fix, push at end.
 ---
 
 # Review-Followup
 
-You are driving the interactive fix-or-dismiss loop against the single
+You are driving the interactive triage loop against the single
 **AI Architectural Review** comment posted by the review bot (see
 `.github/workflows/claude-code-review.yml` and
 `.github/ai-review-prompt.md`).
@@ -13,17 +13,24 @@ You are driving the interactive fix-or-dismiss loop against the single
 ## Ground rules
 
 - The review lives in **one** comment per PR, edited in place by the bot.
-- Each finding is a markdown task-list line that starts with `- [ ]`,
-  `- [x]`, or `- [D]`:
-  - `- [ ]` → open, needs triage.
-  - `- [x]` → maintainer-accepted / implemented. **Never modify.**
-  - `- [D]` → maintainer-dismissed (permanent won't-fix). **Never modify.**
+- Each finding is a markdown task-list line that starts with `- [ ]`
+  or `- [x]`, optionally followed by a suffix that records maintainer
+  intent:
+  - `- [ ] <finding>` → open, needs triage.
+  - `- [ ] <finding> — _discuss: <note>_` → open, but the maintainer
+    parked it for further discussion. Still surfaces in future triage
+    runs; the note reminds you why it was left open.
+  - `- [x] <finding>` → maintainer-accepted / implemented. **Never
+    modify.**
+  - `- [x] <finding> — _dismissed: <reason>_` → maintainer-dismissed
+    (permanent won't-fix, expressed as a final tick with a reason
+    suffix). **Never modify.**
 - Four sections exist, in this order: `Must-fix`, `Consider`, `Noted`,
   `Skipped`. Only items in the first three are triaged; `Skipped` is
   informational.
 - Line wording from the bot is authoritative — when flipping state,
-  preserve the original line verbatim and only change the marker and
-  append a suffix.
+  preserve the original line verbatim and only change the marker
+  and/or append a suffix.
 
 ## Step 1 — Locate the PR
 
@@ -56,15 +63,17 @@ job run yet?" Do **not** create one.
 
 Split the body into sections by the headings (`### Must-fix`,
 `### Consider`, `### Noted`, `### Skipped`). Within each triaged
-section, extract every `- [ ]` / `- [x]` / `- [D]` line and capture:
+section, extract every `- [ ]` / `- [x]` line and capture:
 
-- state marker (` `, `x`, `D`)
-- the full line text (verbatim, no rephrasing)
+- state marker (` ` or `x`)
+- the full line text (verbatim, no rephrasing), including any
+  `— _dismissed: ..._` / `— _discuss: ..._` suffix
 - any cited `path/to/file.rs:LINE` reference (best-effort regex)
 
-Build a worklist of only the `- [ ]` items. If the worklist is empty,
-tell the user "nothing to triage on PR #$PR" and stop — do not push,
-do not commit.
+Build a worklist of all `- [ ]` items (including ones with a
+`— _discuss: ..._` suffix — those were parked for later, and "later"
+may be now). If the worklist is empty, tell the user "nothing to
+triage on PR #$PR" and stop — do not push, do not commit.
 
 ## Step 4 — Triage loop
 
@@ -73,8 +82,9 @@ For each open item, one at a time in section order (Must-fix first):
 1. Show the finding to the user along with the relevant code context.
    If the finding cites `path/to/file.rs:LINE`, Read a window around
    that line (roughly ±20 lines) so the user sees the code before
-   deciding.
-2. Ask the user: **fix** or **dismiss**?
+   deciding. If the line already has a `— _discuss: ..._` suffix,
+   surface that note explicitly ("previously parked: <note>").
+2. Ask the user: **fix**, **dismiss**, or **discuss**?
 3. On **fix**:
    - Plan the change, apply it with normal tools (Edit/Grep/etc.).
    - Run any obviously-relevant check (e.g. `just clippy` for a lint
@@ -87,68 +97,90 @@ For each open item, one at a time in section order (Must-fix first):
      re-stage into a NEW commit (never `--amend`).
 4. On **dismiss**:
    - Ask the user for a one-line reason.
-   - Flip this line from `- [ ]` to `- [D]` and append
-     ` — _dismissed: <reason>_`.
+   - Flip this line from `- [ ]` to `- [x]` and append
+     ` — _dismissed: <reason>_`. The `[x]` signals "final" to the
+     review bot; the suffix records *why* it's final (won't-fix vs
+     implemented).
+   - Update the comment body on GitHub (see Step 5).
+5. On **discuss**:
+   - Ask the user for a one-line note ("what do you want to discuss
+     about this?").
+   - Leave the marker as `- [ ]` and append ` — _discuss: <note>_`.
+     If the line already has a `— _discuss: ..._` suffix from a
+     prior run, replace that suffix with the new note (don't stack
+     them).
    - Update the comment body on GitHub (see Step 5).
 
-Do **not** batch dismissals — apply each one to the GH comment as it
-happens, so a mid-session abort still leaves consistent state.
+Do **not** batch comment-body edits — apply each dismissal/discuss
+flip to the GH comment as it happens, so a mid-session abort still
+leaves consistent state.
 
 ## Step 5 — Editing the GH comment
 
-When flipping an item to `- [D]`:
+Applies to both **dismiss** (flip `[ ]` → `[x]`, append
+`— _dismissed: <reason>_`) and **discuss** (keep `[ ]`, append or
+replace `— _discuss: <note>_`).
 
 1. **Re-fetch the current body** by comment id — it may have changed
-   since step 2 if the bot re-ran:
+   since step 2 if the bot re-ran. Use `mktemp` so concurrent
+   sessions don't clobber each other:
 
    ```bash
-   gh api /repos/{owner}/{repo}/issues/comments/<id> --jq .body > /tmp/review-body.md
+   BODY_FILE=$(mktemp --suffix=.md)
+   trap 'rm -f "$BODY_FILE"' EXIT
+   gh api "/repos/$(gh repo view --json nameWithOwner --jq .nameWithOwner)/issues/comments/<id>" \
+     --jq .body > "$BODY_FILE"
    ```
 
-   (Get `{owner}/{repo}` from `gh repo view --json nameWithOwner --jq .nameWithOwner`.)
-
 2. Do an exact-text line replacement on the file — match the full
-   original `- [ ] ...` line and replace with
-   `- [D] ... — _dismissed: <reason>_`. If the line can't be found
-   verbatim (bot rewrote it on a concurrent run), abort this
-   dismissal and tell the user — do not guess.
+   original line verbatim and replace with the new line:
+   - dismiss: `- [ ] <text>` → `- [x] <text> — _dismissed: <reason>_`
+   - discuss (first time): `- [ ] <text>` → `- [ ] <text> — _discuss: <note>_`
+   - discuss (replacing a prior discuss note):
+     `- [ ] <text> — _discuss: <old>_` → `- [ ] <text> — _discuss: <new>_`
+
+   If the line can't be found verbatim (bot rewrote it on a
+   concurrent run), abort this flip and tell the user — do not guess.
 
 3. PATCH the comment:
 
    ```bash
-   gh api -X PATCH /repos/{owner}/{repo}/issues/comments/<id> \
-     -F body=@/tmp/review-body.md
+   gh api -X PATCH "/repos/$(gh repo view --json nameWithOwner --jq .nameWithOwner)/issues/comments/<id>" \
+     -F body=@"$BODY_FILE"
    ```
 
    (`-F body=@file` reads the file as the body field — safer than
    `-f body="$(cat ...)"` which can blow up on shell-special chars.)
 
 4. Verify success by re-reading the comment body and confirming the
-   `- [D]` line is present.
+   new line is present with the correct marker and suffix.
 
 ## Step 6 — Session end
 
 Once the worklist is exhausted:
 
 1. `git push` the accumulated fix commits. If there were no fixes
-   (only dismissals), skip the push — dismissals live on GitHub, not
-   in git.
+   (only dismissals and/or discuss flips), skip the push — those
+   live on GitHub, not in git.
 2. Tell the user:
-   - How many items were fixed vs dismissed.
+   - How many items were fixed vs dismissed vs parked for discussion.
    - That the review bot will re-run on push and may surface new
      findings.
    - To re-invoke `/review-followup` once the next review comment
-     lands.
+     lands, or sooner to revisit any `— _discuss: ..._` items.
 
 ## Safety rails (do not break)
 
-- Never rewrite `- [x]` or `- [D]` lines — both are final.
+- Never modify `- [x]` lines — they are final, regardless of whether
+  they carry a `— _dismissed: ..._` suffix.
+- Never strip a `— _dismissed: ..._` or `— _discuss: ..._` suffix from
+  any line. Treat suffixes as maintainer intent that must be preserved.
 - Never post a second top-level PR comment.
 - Never `git push --force` from this skill.
-- If a dismissed item resurfaces as `- [ ]` on a later run, flag it
-  to the user ("this was dismissed before — the bot didn't honor it")
-  rather than silently re-dismissing. That's a review-prompt bug
-  worth surfacing.
+- If a previously-dismissed item (was `- [x] ... — _dismissed: ..._`)
+  resurfaces as `- [ ]` on a later run, flag it to the user ("this
+  was dismissed before — the bot didn't honor it") rather than
+  silently re-dismissing. That's a review-prompt bug worth surfacing.
 - If the user course-corrects mid-fix ("no, don't change that"),
   revert the staged edits and return to triage of the next item.
   Don't commit a half-baked fix.

--- a/.github/ai-review-prompt.md
+++ b/.github/ai-review-prompt.md
@@ -136,6 +136,14 @@ these rules:
 - **Maintainer-ticked items** (`- [x]` on a line you know you wrote
   as `- [ ]`): **never untick.** Treat the maintainer's tick as final
   acknowledgement.
+- **Maintainer-dismissed items** (`- [D]` on a line you know you wrote
+  as `- [ ]`, typically with a ` — _dismissed: <reason>_` suffix):
+  **never modify.** Treat `- [D]` exactly like `- [x]` — final
+  acknowledgement that the maintainer does not want this addressed.
+  Preserve the line verbatim, including the suffix. Do not re-raise
+  the same finding in a later run; if you genuinely believe the
+  concern has changed shape, file it as a new bullet with distinct
+  wording rather than resurrecting the dismissed one.
 - **Newly-discovered items** (issues that only appear in the new
   push): append as fresh `- [ ]` bullets in the appropriate section.
 - **Items that became irrelevant** (e.g. the flagged file was

--- a/.github/ai-review-prompt.md
+++ b/.github/ai-review-prompt.md
@@ -135,15 +135,18 @@ these rules:
   rephrase for cosmetic reasons.
 - **Maintainer-ticked items** (`- [x]` on a line you know you wrote
   as `- [ ]`): **never untick.** Treat the maintainer's tick as final
-  acknowledgement.
-- **Maintainer-dismissed items** (`- [D]` on a line you know you wrote
-  as `- [ ]`, typically with a ` — _dismissed: <reason>_` suffix):
-  **never modify.** Treat `- [D]` exactly like `- [x]` — final
-  acknowledgement that the maintainer does not want this addressed.
-  Preserve the line verbatim, including the suffix. Do not re-raise
-  the same finding in a later run; if you genuinely believe the
-  concern has changed shape, file it as a new bullet with distinct
-  wording rather than resurrecting the dismissed one.
+  acknowledgement. If the line carries a ` — _dismissed: <reason>_`
+  suffix, that signals maintainer-dismissed (permanent won't-fix) as
+  opposed to implemented — preserve the suffix verbatim and do not
+  re-raise the same finding in a later run. If you genuinely believe
+  the concern has changed shape, file it as a new bullet with
+  distinct wording rather than resurrecting the dismissed one.
+- **Maintainer-deferred items** (`- [ ]` still open, but with a
+  ` — _discuss: <note>_` suffix appended by the maintainer):
+  treat as still-outstanding — preserve the line verbatim, including
+  the suffix, and do not rephrase it. The note records why the
+  maintainer parked the finding for further discussion; it is not a
+  request for you to act on it.
 - **Newly-discovered items** (issues that only appear in the new
   push): append as fresh `- [ ]` bullets in the appropriate section.
 - **Items that became irrelevant** (e.g. the flagged file was


### PR DESCRIPTION
## Summary
- New `/review-followup` skill drives an interactive triage loop against the AI Architectural Review comment: fetch the comment, walk open `- [ ]` items, fix / dismiss / park-for-discussion each, commit per fix, push at end.
- Introduces two suffix conventions on review-bot lines so maintainer intent survives bot re-runs:
  - `- [x] <finding> — _dismissed: <reason>_` → maintainer-rejected (permanent won't-fix). Uses `[x]` so GitHub renders it as ticked, with the suffix recording *why* it's final.
  - `- [ ] <finding> — _discuss: <note>_` → still open, parked for discussion; future triage runs surface it again with the note attached.
- Updates `.github/ai-review-prompt.md` so the bot preserves both suffixes verbatim and never resurrects a dismissed finding.

## Why `[x] + _dismissed:_` instead of a custom `[D]` marker
GitHub-flavored markdown only renders `[ ]` and `[x]` as task-list checkboxes; a `[D]` marker shows up as raw text. Reusing `[x]` keeps the rendered checklist clean and lets the suffix carry the dismissed-vs-implemented distinction.

## Test plan
- [ ] Run `/review-followup` on a PR with at least one `- [ ]` item and verify it walks open items in section order, lets you fix / dismiss / discuss, and PATCHes the comment per dismissal or discuss flip.
- [ ] Verify the next bot re-run preserves `— _dismissed: ..._` lines verbatim and does not re-raise dismissed findings.
- [ ] Verify `— _discuss: ..._` lines stay `- [ ]` across bot re-runs and re-surface in the next `/review-followup` invocation.
- [ ] Confirm aborting mid-session leaves the GH comment in a consistent state (no batched dismissals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)